### PR TITLE
Code cleanup: Removed empty pending specs

### DIFF
--- a/spec/actors/hyrax/actors/conference_proceeding_actor_spec.rb
+++ b/spec/actors/hyrax/actors/conference_proceeding_actor_spec.rb
@@ -1,9 +1,0 @@
-# Generated via
-#  `rails generate hyrax:work ConferenceProceeding`
-require 'rails_helper'
-
-RSpec.describe Hyrax::Actors::ConferenceProceedingActor do
-  it "has tests" do
-    skip "Add your tests here"
-  end
-end

--- a/spec/actors/hyrax/actors/data_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/data_set_actor_spec.rb
@@ -1,9 +1,0 @@
-# Generated via
-#  `rails generate hyrax:work DataSet`
-require 'rails_helper'
-
-RSpec.describe Hyrax::Actors::DataSetActor do
-  it "has tests" do
-    skip "Add your tests here"
-  end
-end

--- a/spec/actors/hyrax/actors/publication_actor_spec.rb
+++ b/spec/actors/hyrax/actors/publication_actor_spec.rb
@@ -1,9 +1,0 @@
-# Generated via
-#  `rails generate hyrax:work Publication`
-require 'rails_helper'
-
-RSpec.describe Hyrax::Actors::PublicationActor do
-  it "has tests" do
-    skip "Add your tests here"
-  end
-end

--- a/spec/controllers/hyrax/conference_proceedings_controller_spec.rb
+++ b/spec/controllers/hyrax/conference_proceedings_controller_spec.rb
@@ -1,9 +1,0 @@
-# Generated via
-#  `rails generate hyrax:work ConferenceProceeding`
-require 'rails_helper'
-
-RSpec.describe Hyrax::ConferenceProceedingsController do
-  it "has tests" do
-    skip "Add your tests here"
-  end
-end

--- a/spec/controllers/hyrax/data_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/data_sets_controller_spec.rb
@@ -1,9 +1,0 @@
-# Generated via
-#  `rails generate hyrax:work DataSet`
-require 'rails_helper'
-
-RSpec.describe Hyrax::DataSetsController do
-  it "has tests" do
-    skip "Add your tests here"
-  end
-end

--- a/spec/controllers/hyrax/publications_controller_spec.rb
+++ b/spec/controllers/hyrax/publications_controller_spec.rb
@@ -1,9 +1,0 @@
-# Generated via
-#  `rails generate hyrax:work Publication`
-require 'rails_helper'
-
-RSpec.describe Hyrax::PublicationsController do
-  it "has tests" do
-    skip "Add your tests here"
-  end
-end

--- a/spec/forms/hyrax/conference_proceeding_form_spec.rb
+++ b/spec/forms/hyrax/conference_proceeding_form_spec.rb
@@ -1,9 +1,0 @@
-# Generated via
-#  `rails generate hyrax:work ConferenceProceeding`
-require 'rails_helper'
-
-RSpec.describe Hyrax::ConferenceProceedingForm do
-  it "has tests" do
-    skip "Add your tests here"
-  end
-end

--- a/spec/forms/hyrax/data_set_form_spec.rb
+++ b/spec/forms/hyrax/data_set_form_spec.rb
@@ -1,9 +1,0 @@
-# Generated via
-#  `rails generate hyrax:work DataSet`
-require 'rails_helper'
-
-RSpec.describe Hyrax::DataSetForm do
-  it "has tests" do
-    skip "Add your tests here"
-  end
-end

--- a/spec/forms/hyrax/publication_form_spec.rb
+++ b/spec/forms/hyrax/publication_form_spec.rb
@@ -1,9 +1,0 @@
-# Generated via
-#  `rails generate hyrax:work Publication`
-require 'rails_helper'
-
-RSpec.describe Hyrax::PublicationForm do
-  it "has tests" do
-    skip "Add your tests here"
-  end
-end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Collection do
-  it "has tests" do
-    skip "Add your tests here"
-  end
-end

--- a/spec/models/conference_proceeding_spec.rb
+++ b/spec/models/conference_proceeding_spec.rb
@@ -1,9 +1,0 @@
-# Generated via
-#  `rails generate hyrax:work ConferenceProceeding`
-require 'rails_helper'
-
-RSpec.describe ConferenceProceeding do
-  it "has tests" do
-    skip "Add your tests here"
-  end
-end

--- a/spec/models/data_set_spec.rb
+++ b/spec/models/data_set_spec.rb
@@ -1,9 +1,0 @@
-# Generated via
-#  `rails generate hyrax:work DataSet`
-require 'rails_helper'
-
-RSpec.describe DataSet do
-  it "has tests" do
-    skip "Add your tests here"
-  end
-end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe FileSet do
-  it "has tests" do
-    skip "Add your tests here"
-  end
-end

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -1,9 +1,0 @@
-# Generated via
-#  `rails generate hyrax:work Publication`
-require 'rails_helper'
-
-RSpec.describe Publication do
-  it "has tests" do
-    skip "Add your tests here"
-  end
-end

--- a/spec/models/qa/local_authority_entry_spec.rb
+++ b/spec/models/qa/local_authority_entry_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Qa::LocalAuthorityEntry, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/qa/local_authority_spec.rb
+++ b/spec/models/qa/local_authority_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Qa::LocalAuthority, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/presenters/hyrax/conference_proceeding_presenter_spec.rb
+++ b/spec/presenters/hyrax/conference_proceeding_presenter_spec.rb
@@ -1,9 +1,0 @@
-# Generated via
-#  `rails generate hyrax:work ConferenceProceeding`
-require 'rails_helper'
-
-RSpec.describe Hyrax::ConferenceProceedingPresenter do
-  it "has tests" do
-    skip "Add your tests here"
-  end
-end

--- a/spec/presenters/hyrax/data_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/data_set_presenter_spec.rb
@@ -1,9 +1,0 @@
-# Generated via
-#  `rails generate hyrax:work DataSet`
-require 'rails_helper'
-
-RSpec.describe Hyrax::DataSetPresenter do
-  it "has tests" do
-    skip "Add your tests here"
-  end
-end

--- a/spec/presenters/hyrax/publication_presenter_spec.rb
+++ b/spec/presenters/hyrax/publication_presenter_spec.rb
@@ -1,9 +1,0 @@
-# Generated via
-#  `rails generate hyrax:work Publication`
-require 'rails_helper'
-
-RSpec.describe Hyrax::PublicationPresenter do
-  it "has tests" do
-    skip "Add your tests here"
-  end
-end


### PR DESCRIPTION
On my laptop, removing all these empty specs makes specs run in 4 seconds instead of 34 seconds.