### PR TITLE
Allow importer input XML to set work's model. Story #71.

### DIFF
--- a/app/lib/contentdm/importer.rb
+++ b/app/lib/contentdm/importer.rb
@@ -47,7 +47,7 @@ module Contentdm
       cdm_record = Contentdm::Record.new(record)
       # TODO: How to know whether a work is a Publication, DataSet, ConferenceProceeding, etc?
       @log.info "Creating new Publication for #{cdm_record.identifer}"
-      work = Publication.new
+      work = work_model(cdm_record.work_type).new
       work.title = cdm_record.title
       work.creator = cdm_record.creators
       work.contributor = cdm_record.contributors
@@ -69,6 +69,17 @@ module Contentdm
     # @return [ActiveFedora::Base] return the collection object
     def collection
       CollectionBuilder.new(collection_name).find_or_create
+    end
+
+    # Converts a class name into a class.
+    # @param class_name [String] the type of work we want to create, 'Publication', 'ConferenceProceeding', or 'DataSet'.
+    # @return [Class] return the work's class
+    # @example If you pass in a string 'Publication', it returns the class ::Publication
+    def work_model(class_name)
+      # todo - don't hard-code Publication
+      class_name.constantize || Publication
+    rescue NameError
+      raise "Invalid work type: #{class_name}"
     end
 
     private

--- a/app/lib/contentdm/record.rb
+++ b/app/lib/contentdm/record.rb
@@ -78,6 +78,13 @@ module Contentdm
       remove_nils([@record_hash["publisher"]])
     end
 
+    ##
+    # @return [String]
+    # returns the type of work that will determine the model
+    def work_type
+      @record_hash["work_type"]
+    end
+
     private
 
       ##

--- a/spec/fixtures/files/ContentDM_XML_Full_Fields.xml
+++ b/spec/fixtures/files/ContentDM_XML_Full_Fields.xml
@@ -20,6 +20,7 @@
     <created>1975-09</created>
     <modified>2008-12-03</modified>
     <identifier>19750900fedmwp22</identifier>
+    <work_type>Publication</work_type>
     <relation></relation>
     <isPartOf>Working paper (Federal Reserve Bank of Minneapolis. Research Dept.)</isPartOf>
     <requires>22</requires>

--- a/spec/lib/contentdm/importer_spec.rb
+++ b/spec/lib/contentdm/importer_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Contentdm::Importer do
   let(:cdmi) { described_class.new(input_file) }
-  let(:input_file) { File.join(fixture_path, 'files', 'ContentDM_XML_Full_Fields.xml') }
+  let(:input_file) { file_fixture('ContentDM_XML_Full_Fields.xml') }
 
   context "processing an export file" do
     it "can instantiate" do
@@ -39,6 +39,23 @@ describe Contentdm::Importer do
       work = cdmi.process_record(@record)
       cdmi.collection.save
       expect(cdmi.collection.members.last.id).to eq(work.id)
+    end
+  end
+
+  describe "#work_model" do
+    subject(:model) { cdmi.work_model(model_name) }
+
+    context "with a valid string name for a model" do
+      let(:model_name) { "ConferenceProceeding" }
+      it { is_expected.to eq ConferenceProceeding }
+    end
+
+    context "with an invalid string" do
+      let(:model_name) { 'Conference Proceeding' }
+
+      it "raises an error" do
+        expect { model }.to raise_error("Invalid work type: Conference Proceeding")
+      end
     end
   end
 end

--- a/spec/lib/contentdm/record_spec.rb
+++ b/spec/lib/contentdm/record_spec.rb
@@ -33,5 +33,9 @@ RSpec.describe Contentdm::Record do
     it 'returns an array of publishers' do
       expect(record.publishers).to eq(['Minneapolis : Federal Reserve Bank of Minneapolis'])
     end
+
+    it 'returns a work_type' do
+      expect(record.work_type).to eq 'Publication'
+    end
   end
 end


### PR DESCRIPTION
The input XML file can contain a <work_type> entry, and the importer
will create a work with that model.  For now I hard-coded a default
model to Publication, but that is temporary until work is done for #70.