### PR TITLE
Changed the required fields so that only title is required. Story #114.

### DIFF
--- a/app/forms/hyrax/conference_proceeding_form.rb
+++ b/app/forms/hyrax/conference_proceeding_form.rb
@@ -5,5 +5,6 @@ module Hyrax
     self.model_class = ::ConferenceProceeding
     self.terms += [:resource_type]
     self.terms += ::Attributes.to_a
+    self.required_fields = [:title]
   end
 end

--- a/app/forms/hyrax/data_set_form.rb
+++ b/app/forms/hyrax/data_set_form.rb
@@ -5,5 +5,6 @@ module Hyrax
     self.model_class = ::DataSet
     self.terms += [:resource_type]
     self.terms += ::Attributes.to_a
+    self.required_fields = [:title]
   end
 end

--- a/app/forms/hyrax/publication_form.rb
+++ b/app/forms/hyrax/publication_form.rb
@@ -5,5 +5,6 @@ module Hyrax
     self.model_class = ::Publication
     self.terms += [:resource_type]
     self.terms += ::Attributes.to_a
+    self.required_fields = [:title]
   end
 end

--- a/spec/features/create_conference_proceeding_spec.rb
+++ b/spec/features/create_conference_proceeding_spec.rb
@@ -3,8 +3,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-# NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a ConferenceProceeding', js: false do
+RSpec.feature 'Create a ConferenceProceeding', js: true do
   context 'a logged in user' do
     let(:user_attributes) do
       { email: 'test@example.com' }
@@ -21,6 +20,11 @@ RSpec.feature 'Create a ConferenceProceeding', js: false do
     scenario do
       visit '/concern/conference_proceedings/new'
       expect(page).to have_content "Add New Conference Proceeding"
+
+      # Only the 'title' field should be required
+      expect(page).to have_css('li#required-metadata.incomplete')
+      fill_in 'Title', with: 'Title 123'
+      expect(page).to have_css('li#required-metadata.complete')
     end
   end
 end

--- a/spec/features/create_data_set_spec.rb
+++ b/spec/features/create_data_set_spec.rb
@@ -3,8 +3,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-# NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a DataSet', js: false do
+RSpec.feature 'Create a DataSet', js: true do
   context 'a logged in user' do
     let(:user_attributes) do
       { email: 'test@example.com' }
@@ -21,6 +20,11 @@ RSpec.feature 'Create a DataSet', js: false do
     scenario do
       visit '/concern/data_sets/new'
       expect(page).to have_content "Add New Data Set"
+
+      # Only the 'title' field should be required
+      expect(page).to have_css('li#required-metadata.incomplete')
+      fill_in 'Title', with: 'Title 123'
+      expect(page).to have_css('li#required-metadata.complete')
     end
   end
 end

--- a/spec/features/create_publication_spec.rb
+++ b/spec/features/create_publication_spec.rb
@@ -11,14 +11,19 @@ RSpec.feature 'Create a Publication', js: true do
       AdminSet.find_or_create_default_admin_set_id
     end
 
-    scenario do
+    scenario 'fill in and submit the form' do
       visit '/concern/publications/new'
       expect(page).to have_content "Add New Publication"
+
+      # Only the 'title' field should be required
+      expect(page).to have_css('li#required-metadata.incomplete')
       fill_in 'Title', with: 'Title'
+      expect(page).to have_css('li#required-metadata.complete')
+
+      click_on 'Additional fields'
       fill_in 'Creator', with: 'Creator'
       fill_in 'Keyword', with: 'Keyword'
       select 'In Copyright', from: 'Rights statement'
-      click_on 'Additional fields'
       fill_in 'Abstract', with: 'Abstract'
       fill_in 'Alternative Title', with: 'Alternative Title'
       fill_in 'Bibliographic Citation', with: 'Bibliographic Citation'
@@ -51,8 +56,10 @@ RSpec.feature 'Create a Publication', js: true do
       sleep(1)
       find('#agreement').click
 
+      # Save the form
       find('#with_files_submit').click
 
+      # Now we are on the show page for the new record
       expect(page).to have_content('Abstract')
       expect(page).to have_content('Alternative Title')
       expect(page).to have_content('Bibliographic Citation')


### PR DESCRIPTION
We had a problem where records that were created by the importer were
marked as 'invalid' by the edit form because they were missing some
required fields.  After discussion, we decided that the only required
field should be title.  Records created by the importer should be
considered 'valid' by the form.