### PR TITLE
Ensure XML is valid before importing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,8 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'web-console', '>= 3.3.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+  gem 'pry'
+  gem 'pry-doc'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'yard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,7 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     clipboard-rails (1.7.1)
     cliver (0.3.2)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -537,6 +538,12 @@ GEM
     posix-spawn (0.3.13)
     power_converter (0.1.2)
     powerpack (0.1.1)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-doc (0.12.0)
+      pry (~> 0.9)
+      yard (~> 0.9)
     public_suffix (3.0.1)
     puma (3.11.0)
     qa (2.0.0)
@@ -847,6 +854,8 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg (~> 0.18)
   poltergeist
+  pry
+  pry-doc
   puma (~> 3.7)
   rails (~> 5.1.4)
   rainbow

--- a/app/lib/contentdm/record.rb
+++ b/app/lib/contentdm/record.rb
@@ -34,7 +34,7 @@ module Contentdm
     # the title without the / Author, Name
     # part at the end and without any spaces at the end
     def title
-      get_values(@record_hash["title"]).map { |title| title.split('/')[0].strip! }
+      get_values(remove_author(@record_hash["title"]))
     end
 
     ##
@@ -153,8 +153,19 @@ module Contentdm
         property.select { |prop| !prop.nil? }
       end
 
+      ##
+      # @param values [Array]
+      # @return [Array]
       def strip_whitespace(values)
         values.map { |v| v.strip }
+      end
+
+      ##
+      # @param title [String]
+      # @return [String]
+      def remove_author(title)
+        return title unless title.include?('/')
+        title.split('/')[0].strip!
       end
   end
 end

--- a/app/lib/contentdm/schema/cdm_export.rng
+++ b/app/lib/contentdm/schema/cdm_export.rng
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start>
+    <ref name="export"/>
+  </start>
+
+  <!-- This defines the basic structure of the
+       import XML. It says that it needs
+       to have a <metadata> element with a
+       <collection_name> and a <record> element
+       that at least has a <title> element -->
+  <define name="export">
+    <element name="metadata">
+      <element name="collection_name">
+        <text/>
+      </element>
+      <oneOrMore>
+        <element name="record">
+          <oneOrMore>
+            <element name="title">
+              <text/>
+            </element>
+          </oneOrMore>
+          <oneOrMore>
+            <ref name="anyElement"/>
+          </oneOrMore>
+        </element>
+      </oneOrMore>
+    </element>
+  </define>
+
+  <!-- This lets us say that that an element can have any
+       elements nested in it. Our export only needs to have
+       a <title> element.
+  -->
+  <define name="anyElement">
+        <element>
+            <anyName/>
+            <ref name="anyAttributes"/>
+            <mixed>
+                <zeroOrMore>
+                    <ref name="anyElement"/>
+                </zeroOrMore>
+            </mixed>
+        </element>
+    </define>
+    <define name="anyAttributes">
+        <zeroOrMore>
+            <attribute>
+                <anyName/>
+            </attribute>
+        </zeroOrMore>
+    </define>
+</grammar>

--- a/app/lib/contentdm/validator.rb
+++ b/app/lib/contentdm/validator.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+module Contentdm
+  # This class loads a RelaxNG schema that is used to validate
+  # the CDM export xml.
+  class Validator
+    attr_reader :result
+
+    ##
+    # @param [File] xml_file
+    # @return [Array]
+    # Sets the result of validation during the init
+    def initialize(xml_file)
+      schema_file = Rails.root.join('app', 'lib', 'contentdm', 'schema', 'cdm_export.rng')
+      schema = Nokogiri::XML::RelaxNG(File.open(schema_file))
+      doc = Nokogiri::XML(File.open(xml_file))
+      @result = schema.validate(doc)
+    end
+
+    ##
+    # @return [Boolean]
+    # Returns a boolean for the validation result
+    def valid?
+      @result.empty?
+    end
+
+    ##
+    # This method will log the result of validation and
+    # raise an error if the XML is invalid
+    def validate
+      if valid?
+        Contentdm::Log.new('XML is valid', 'info')
+      else
+        Contentdm::Log.new('XML is invalid', 'error')
+        raise 'XML is invalid'
+      end
+    end
+  end
+end

--- a/spec/fixtures/files/cdm_xml_with_errors.xml
+++ b/spec/fixtures/files/cdm_xml_with_errors.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<metadata>
+  <collection_name>Sargent and Sims</collection_name>
+  <record>
+    <creator>Hansen, Lars Peter.</creator>
+    <creator>Sargent, Thomas J.</creator>
+    <creator></creator>
+    <creator></creator>
+    <contributor>Federal Reserve Bank of Minneapolis. Research Department.</contributor>
+    <subject>Time-series analysis.</subject>
+    <subject></subject>
+    <subject></subject>
+    <subject></subject>
+    <subject></subject>
+    <subject></subject>
+    <subject></subject>
+    <subject></subject>
+    <description></description>
+    <abstract></abstract>
+    <tableOfContents></tableOfContents>
+    <created></created>
+    <modified></modified>
+    <legacyFileName></legacyFileName>
+    <relation></relation>
+    <isPartOf>Staff report (Federal Reserve Bank of Minneapolis. Research Dept.)</isPartOf>
+    <requires>75</requires>
+    <publisher>Minneapolis : Federal Reserve Bank of Minneapolis.</publisher>
+    <format>PDF</format>
+    <alternative></alternative>
+    <alternative></alternative>
+    <alternative></alternative>
+    <isReplacedBy></isReplacedBy>
+    <replaces></replaces>
+    <requires></requires>
+    <unmapped></unmapped>
+    <fullResolution></fullResolution>
+    <cdmid>58</cdmid>
+    <cdmaccess></cdmaccess>
+    <cdmcreated>2012-04-12</cdmcreated>
+    <cdmmodified>2012-04-12</cdmmodified>
+    <cdmoclc></cdmoclc>
+    <cdmfile>59.url</cdmfile>
+    <cdmpath>/p16030coll1/image/59.url</cdmpath>
+    <thumbnailURL>http://server16030.contentdm.oclc.org/cgi-bin/thumbnail.exe?CISOROOT=/p16030coll1&amp;CISOPTR=58</thumbnailURL>
+    <viewerURL>http://cdm16030.contentdm.oclc.org/cdm/ref/collection/p16030coll1/id/58</viewerURL>
+    <structure>http://server16030.contentdm.oclc.org/cgi-bin/showfile.exe?CISOROOT=/p16030coll1&amp;CISOPTR=58</structure>
+  </record>
+</metadata>

--- a/spec/lib/contentdm/validator_spec.rb
+++ b/spec/lib/contentdm/validator_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require 'rails_helper'
+RSpec.describe Contentdm::Validator do
+  let(:xml) { file_fixture('ContentDM_XML_Full_Fields.xml') }
+  let(:invalid_xml) { file_fixture('cdm_xml_with_errors.xml') }
+  let(:validator) { described_class.new(xml) }
+  let(:validator_bad_xml) { described_class.new(invalid_xml) }
+
+  context 'validating a valid export xml document' do
+    it 'returns that the xml document has no errors' do
+      expect(validator.result.empty?).to eq(true)
+    end
+
+    describe '#valid?' do
+      it 'returns true' do
+        expect(validator.valid?).to eq(true)
+      end
+    end
+
+    describe '#validate' do
+      it 'raises an exception' do
+        expect { validator.validate }.not_to raise_error
+      end
+    end
+  end
+
+  context 'validating an invalid export  xml document' do
+    it 'returns that the xml is not valid' do
+      expect(validator_bad_xml.result.empty?).to eq(false)
+    end
+
+    describe '#valid?' do
+      it 'returns false' do
+        expect(validator_bad_xml.valid?).to eq(false)
+      end
+    end
+
+    describe '#validate' do
+      it 'raises an exception' do
+        expect { validator_bad_xml.validate }.to raise_error('XML is invalid')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a validator class that uses a RelaxNG schema
to ensure that the XML is valid before importing. The XML
must have a `<metadata>` element with a <collection_name> and then
one or more `<record>` elements. The record elements require a
`<title>` element.

This commit also fixes an issue with the method that removes the
author string from titles. Before the title would need to have a
slash in it because the string was being split on the slash, but
now the method will check to see if the title has a slash in it
before splitting. This was causing some records to fail when
importing the Sargent and Sims collection.