### PR TITLE
Don't print error message if successful import with no attached file.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,6 +61,9 @@ Layout/ClosingParenthesisIndentation:
 RSpec/InstanceVariable:
   Enabled: false
 
+RSpec/MessageSpies:
+  Enabled: false
+
 RSpec/NestedGroups:
   Enabled: false
 

--- a/app/lib/contentdm/import_file.rb
+++ b/app/lib/contentdm/import_file.rb
@@ -22,8 +22,9 @@ module Contentdm
 
     ##
     # this returns a Hyrax::Uploaded file object, that will be used when importing
-    # @return [Hyrax::UploadedFile]
+    # @return [Hyrax::UploadedFile, nil]
     def uploaded_file
+      return nil if @record.legacy_file_name.blank?
       if check_for_file(file_path)
         Contentdm::Log.new("Loading file: #{file_path}", 'info')
         Hyrax::UploadedFile.create(user: @user, file: File.open(file_path, 'r'))

--- a/spec/fixtures/files/minimal_record.xml
+++ b/spec/fixtures/files/minimal_record.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<metadata>
+  <collection_name>Sargent and Sims</collection_name>
+  <record>
+    <title>Record 1</title>
+    <subject></subject>
+  </record>
+</metadata>

--- a/spec/lib/contentdm/import_file_spec.rb
+++ b/spec/lib/contentdm/import_file_spec.rb
@@ -11,6 +11,15 @@ describe Contentdm::ImportFile do
   let(:user) { ::User.batch_user }
   let(:import_file) { described_class.new(record, data_path, user) }
 
+  context 'with no entry for legacyFileName' do
+    let(:doc) { File.open(file_fixture('minimal_record.xml')) { |f| Nokogiri::XML(f) } }
+
+    describe '#uploaded_file' do
+      subject { import_file.uploaded_file }
+      it { is_expected.to eq nil }
+    end
+  end
+
   context 'when given the details for creating a new File to import' do
     describe '#uploaded_file' do
       it 'returns a Hyrax::UploadedFile' do

--- a/spec/lib/contentdm/importer_spec.rb
+++ b/spec/lib/contentdm/importer_spec.rb
@@ -66,6 +66,20 @@ describe Contentdm::Importer do
     end
   end
 
+  context 'A record with no file to attach' do
+    let(:input_file) { file_fixture('minimal_record.xml') }
+
+    before do
+      ActiveFedora::Cleaner.clean!
+      AdminSet.find_or_create_default_admin_set_id
+    end
+
+    it 'successfully imports without logging any error messages' do
+      expect(Contentdm::Log).not_to receive(:new).with(any_args, 'error')
+      expect { cdmi.import }.to change { cdmi.work_model.count }.by(1)
+    end
+  end
+
   describe '#work_model' do
     subject(:model) { cdmi.work_model(model_name) }
 


### PR DESCRIPTION
Story #122.

In the case where the input XML file has no '<legacyFileName>' entry,
the record successfully imported, but it printed a false-alarm error
message that said it couldn't find the file.  This code ensures that
unnecessary error message won't be printed.