### PR TITLE
Create an XML file containing records that have failed

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -72,3 +72,6 @@ RSpec/VerifiedDoubles:
 
 Style/BlockDelimiters:
   Enabled: false
+
+RSpec/AnyInstance:
+  Enabled: false

--- a/app/lib/contentdm/importer.rb
+++ b/app/lib/contentdm/importer.rb
@@ -4,7 +4,7 @@ require 'nokogiri'
 # An importer for ContentDM exported Metadata
 module Contentdm
   class Importer
-    attr_reader :doc, :records
+    attr_reader :doc, :records, :problem_record, :problem_record_file_name
     attr_reader :input_file, :data_path, :default_work_model
 
     # @param input_file [String] the path to the XML file that contains the exported records from ContentDM.
@@ -18,6 +18,9 @@ module Contentdm
       @doc = File.open(input_file) { |f| Nokogiri::XML(f) }
       @records = @doc.xpath("//record")
       @collection = collection
+
+      @problem_record_file_name = "#{Time.now.in_time_zone.strftime('%v')}_#{collection_name[0].split(' ').join('_')}.xml"
+      @problem_record = Contentdm::ProblemRecord.new(collection_name[0], Rails.root.join('log', problem_record_file_name))
     end
 
     # Class level method, to be called, e.g., from a rake task
@@ -29,10 +32,21 @@ module Contentdm
 
     def import
       @records.each do |record|
-        work = process_record(record)
-        Contentdm::Log.new("Adding #{work.id} to collection: #{collection_name}", 'info')
+        begin
+          work = process_record(record)
+          Contentdm::Log.new("Adding #{work.id} to collection: #{collection_name[0]}", 'info')
+        rescue
+          Contentdm::Log.new("Problem importing record #{record}", 'error')
+          Contentdm::Log.new("Records that were unable to be imported will be saved at #{@problem_record_file_name}", 'error')
+          rake_command = "rake import:contentdm -- -i #{@problem_record_file_name} -d #{data_path} -w #{default_work_model}"
+          Contentdm::Log.new("To run again: ", 'error')
+          Contentdm::Log.new(rake_command, 'error')
+          @problem_record.add_record(record)
+        end
       end
       @collection.save
+      @problem_record.save_xml
+      @problem_record.clean_up # Remove the problem record if there were no problems
     end
 
     def document_count

--- a/app/lib/contentdm/problem_record.rb
+++ b/app/lib/contentdm/problem_record.rb
@@ -1,0 +1,42 @@
+module Contentdm
+  ##
+  # This class is used for collection records that have
+  # not imported sucessfully and then writing them to
+  # to a file that can be used to re-import them at a
+  # later time
+  class ProblemRecord
+    attr_accessor :doc
+    ##
+    # @param [String, String] collection_name, file_name
+    def initialize(collection_name, file_name)
+      xml_string = %(
+<metadata>
+  <collection_name>#{collection_name}</collection_name>
+</metadata>
+)
+      xml = if File.exist?(file_name)
+              File.open(file_name, 'r')
+            else
+              xml_string
+            end
+      @doc = Nokogiri::XML(xml)
+      @file_name = file_name
+    end
+
+    ##
+    # @param [String] record
+    def add_record(record)
+      @doc.root.add_child(record)
+    end
+
+    def save_xml
+      problem_record_file = File.open(@file_name, 'w')
+      problem_record_file << @doc.to_xml
+      problem_record_file.close
+    end
+
+    def clean_up
+      File.unlink(@file_name) if @doc.xpath('//record').empty?
+    end
+  end
+end

--- a/spec/fixtures/files/ContentDM_XML_Full_Fields.xml
+++ b/spec/fixtures/files/ContentDM_XML_Full_Fields.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <collection_name>Sargent and Sims</collection_name>
+  <collection_name>Test Collection</collection_name>
   <record>
     <title>Classical macroeconomic model for the United States, a / Thomas J. Sargent.</title>
     <creator>Sargent, Thomas J.</creator>

--- a/spec/fixtures/files/cdm_xml_with_errors.xml
+++ b/spec/fixtures/files/cdm_xml_with_errors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <collection_name>Sargent and Sims</collection_name>
+  <collection_name>Test Collection</collection_name>
   <record>
     <creator>Hansen, Lars Peter.</creator>
     <creator>Sargent, Thomas J.</creator>

--- a/spec/fixtures/files/minimal_record.xml
+++ b/spec/fixtures/files/minimal_record.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <collection_name>Sargent and Sims</collection_name>
+  <collection_name>Test Collection</collection_name>
   <record>
     <title>Record 1</title>
     <subject></subject>

--- a/spec/fixtures/files/some_records.xml
+++ b/spec/fixtures/files/some_records.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<metadata>
+  <collection_name>Sargent and Sims</collection_name>
+  <record>
+    <title>Record 111</title>
+    <subject></subject>
+  </record>
+
+  <record>
+    <title>Record 222</title>
+    <subject></subject>
+  </record>
+
+  <record>
+    <title>Record 333</title>
+    <subject></subject>
+  </record>
+
+  <record>
+    <title>Record 444</title>
+    <subject></subject>
+  </record>
+</metadata>

--- a/spec/fixtures/files/some_records.xml
+++ b/spec/fixtures/files/some_records.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <collection_name>Sargent and Sims</collection_name>
+  <collection_name>Test Collection</collection_name>
   <record>
     <title>Record 111</title>
     <subject></subject>

--- a/spec/lib/contentdm/importer_spec.rb
+++ b/spec/lib/contentdm/importer_spec.rb
@@ -9,7 +9,8 @@ describe Contentdm::Importer do
   let(:data_path) { Rails.root.join('spec', 'fixtures', 'files') }
   let(:default_model) { 'DataSet' }
   let(:collection_name) { ['Test Collection'] }
-  let(:problem_record_file_name) { "#{Time.now.in_time_zone.strftime('%v')}_#{collection_name[0].split(' ').join('_')}.xml" }
+  let(:problem_record_file_name) { cdmi.problem_record_file_name }
+
   context 'processing an export file' do
     it 'can instantiate' do
       expect(cdmi).to be_instance_of(described_class)
@@ -85,9 +86,16 @@ describe Contentdm::Importer do
         expect { cdmi.import }.to change { model.count }.by(2)
       end
 
+      it 'logs the errors for the failed records' do
+        expect { cdmi.import }
+          .to output(/Record 222 failed!/).to_stdout_from_any_process
+      end
+
       it 'exports an XML with the failed records' do
+        cdmi.import
         problem_record_file = File.open(Rails.root.join('log', problem_record_file_name))
         expect(problem_record_file.readlines.join).to match(/Record 222/) && match(/Record 444/)
+        problem_record_file.close
       end
     end
   end

--- a/spec/lib/contentdm/importer_spec.rb
+++ b/spec/lib/contentdm/importer_spec.rb
@@ -8,7 +8,8 @@ describe Contentdm::Importer do
   let(:input_file_with_no_title) { file_fixture('cdm_xml_with_errors.xml') }
   let(:data_path) { Rails.root.join('spec', 'fixtures', 'files') }
   let(:default_model) { 'DataSet' }
-
+  let(:collection_name) { ['Test Collection'] }
+  let(:problem_record_file_name) { "#{Time.now.in_time_zone.strftime('%v')}_#{collection_name[0].split(' ').join('_')}.xml" }
   context 'processing an export file' do
     it 'can instantiate' do
       expect(cdmi).to be_instance_of(described_class)
@@ -23,7 +24,7 @@ describe Contentdm::Importer do
       expect(cdmi.input_file).to eq input_file
     end
     it 'can determine the collection title' do
-      expect(cdmi.collection_name).to eq(['Sargent and Sims'])
+      expect(cdmi.collection_name).to eq(['Test Collection'])
     end
     it 'has a default work type' do
       expect(cdmi.default_work_model).to eq 'DataSet'
@@ -85,7 +86,8 @@ describe Contentdm::Importer do
       end
 
       it 'exports an XML with the failed records' do
-        skip 'Write this spec for Story #101'
+        problem_record_file = File.open(Rails.root.join('log', problem_record_file_name))
+        expect(problem_record_file.readlines.join).to match(/Record 222/) && match(/Record 444/)
       end
     end
   end

--- a/spec/lib/contentdm/problem_record_spec.rb
+++ b/spec/lib/contentdm/problem_record_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Contentdm::ProblemRecord do
+  let(:collection_name) { 'Test Collection' }
+  let(:file_name) { Dir::Tmpname.make_tmpname(['problem', '.xml'], nil) }
+  let(:file) { Rails.root.join('tmp', file_name) }
+  let(:problem_record) { described_class.new(collection_name, file) }
+  let(:record_xml) { Nokogiri::XML(file_fixture('some_records.xml')).xpath('//record')[2] }
+  describe '#add_record' do
+    it 'adds a record to the xml document' do
+      problem_record.add_record(record_xml)
+      expect(problem_record.doc.xpath('//record').length).to eq(1)
+    end
+  end
+  describe '#save_xml' do
+    it 'saves the xml to a file' do
+      problem_record.add_record(record_xml)
+      problem_record.save_xml
+      file_with_record = File.open(file)
+      expect(file_with_record.read).to match(/Record 333/)
+      file_with_record.close
+    end
+  end
+  describe '#problem_record' do
+    it 'adds a record to the xml document' do
+      problem_record.save_xml
+      problem_record.clean_up
+      expect(File.exist?(file)).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
This commit introduces a `ProblemRecord` class that will
create an XML document containing `<record>` elements that
have failed during the import process.

The resulting file will be stored in the `/log` directory with
the name of the collection + the date in the filename. If the
file does not exist, one will be created and if you run it
multiple times problematic records will be appended to the
existing file.