### PR TITLE
Support Markdown in Related URL field

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'hyrax', '2.0.1'
+gem 'redcarpet'
 gem 'rubyzip'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -645,6 +645,7 @@ GEM
       rdf (>= 2.2, < 4.0)
     rdf-xsd (2.2.1)
       rdf (>= 2.2, < 4.0)
+    redcarpet (3.4.0)
     redic (1.5.0)
       hiredis
     redis (4.0.1)
@@ -868,6 +869,7 @@ DEPENDENCIES
   puma (~> 3.7)
   rails (~> 5.1.4)
   rainbow
+  redcarpet
   redis-activesupport
   rsolr (>= 1.0)
   rspec-rails

--- a/app/forms/hyrax/conference_proceeding_form.rb
+++ b/app/forms/hyrax/conference_proceeding_form.rb
@@ -6,5 +6,11 @@ module Hyrax
     self.terms += [:resource_type]
     self.terms += ::Attributes.to_a
     self.required_fields = [:title]
+
+    def self.model_attributes(form_params)
+      result = super
+      result[:related_url].map! { |related_url| RDF::Markdown::Literal.new(related_url) }
+      result
+    end
   end
 end

--- a/app/forms/hyrax/data_set_form.rb
+++ b/app/forms/hyrax/data_set_form.rb
@@ -6,5 +6,11 @@ module Hyrax
     self.terms += [:resource_type]
     self.terms += ::Attributes.to_a
     self.required_fields = [:title]
+
+    def self.model_attributes(form_params)
+      result = super
+      result[:related_url].map! { |related_url| RDF::Markdown::Literal.new(related_url) }
+      result
+    end
   end
 end

--- a/app/forms/hyrax/publication_form.rb
+++ b/app/forms/hyrax/publication_form.rb
@@ -6,5 +6,11 @@ module Hyrax
     self.terms += [:resource_type]
     self.terms += ::Attributes.to_a
     self.required_fields = [:title]
+
+    def self.model_attributes(form_params)
+      result = super
+      result[:related_url].map! { |related_url| RDF::Markdown::Literal.new(related_url) }
+      result
+    end
   end
 end

--- a/app/lib/rdf/markdown/literal.rb
+++ b/app/lib/rdf/markdown/literal.rb
@@ -1,0 +1,40 @@
+module RDF
+  module Markdown
+    ##
+    # A Mardownliteral
+    #
+    # @example Initializing an EDTF literal with {RDF::Literal}
+    #    RDF::Literal(my_markdown_string, datatype: RDF::Markdown::Literal::DATATYPE)
+    #
+    class Literal < RDF::Literal
+      DATATYPE = RDF::URI('http://ns.ontowiki.net/SysOnt/Markdown')
+      ##
+      # We punt on a Markdown grammar and accept any string the user throws us as
+      # valid. If your markdown parser barfs, that's your problem.
+      #
+      # @see http://roopc.net/posts/2014/markdown-cfg/
+      GRAMMAR = %r{.*}
+
+      # support ActiveJob serialization
+      include GlobalID::Identification
+      ##
+      # Initializes an RDF::Literal with Mardown datatype.
+      #
+      # Casts lexical values to {String}. Parsing is left as an excerise for the
+      # reader.
+      #
+      # @see {RDF::Literal}
+      def initialize(value, options = {})
+        super
+      end
+
+      def self.find(id)
+        new(id)
+      end
+
+      def id
+        value
+      end
+    end
+  end
+end

--- a/app/renderers/hyrax/renderers/related_url_renderer.rb
+++ b/app/renderers/hyrax/renderers/related_url_renderer.rb
@@ -1,0 +1,15 @@
+module Hyrax
+  module Renderers
+    # This is used by PresentsAttributes to render Related URL fields
+    #   e.g.: presenter.attribute_to_html(:related_url, render_as: :related_url)
+    class RelatedUrlRenderer < AttributeRenderer
+      private
+
+        def attribute_value_to_html(value)
+          renderer = Redcarpet::Render::HTML.new({})
+          markdown = Redcarpet::Markdown.new(renderer, autolink: true)
+          markdown.render(value)
+        end
+    end
+  end
+end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -13,6 +13,7 @@
 <%= presenter.attribute_to_html(:language, render_as: :linked, search_field: 'all_fields' ) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :linked, search_field: 'all_fields' ) %>
 <%= presenter.attribute_to_html(:replaces, render_as: :linked, search_field: 'all_fields' ) %>
+<%= presenter.attribute_to_html(:related_url, render_as: :related_url) %>
 <%= presenter.attribute_to_html(:resource_type, render_as: :linked, search_field: 'all_fields' ) %>
 <%= presenter.attribute_to_html(:rights, render_as: :linked, search_field: 'all_fields' ) %>
 <%= presenter.attribute_to_html(:source, render_as: :linked, search_field: 'all_fields' ) %>

--- a/app/views/records/edit_fields/_description.html.erb
+++ b/app/views/records/edit_fields/_description.html.erb
@@ -1,0 +1,5 @@
+<% if f.object.multiple? key %>
+  <%= f.input :description, as: :multi_value, input_html: { rows: '14', type: 'textarea'}, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input :description, as: :text, input_html: { rows: '14' }, required: f.object.required?(key) %>
+<% end %>

--- a/app/views/records/edit_fields/_related_url.html.erb
+++ b/app/views/records/edit_fields/_related_url.html.erb
@@ -1,0 +1,1 @@
+<%= f.input :related_url, as: :multi_value, input_html: { rows: '14', type: 'textarea'}, required: f.object.required?(key) %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -60,6 +60,9 @@ en:
           table_of_contents: Table of Contents
           title: Title
   simple_form:
+    hints:
+      defaults:
+         related_url: An example is the URL of a research project from which the work was derived. In this box you can use Markdown to create a link to the resource. This link contains <a href="https://daringfireball.net/projects/markdown/syntax#link">Markdown link instructions</a>. You can also use HTML and if you enter a URL by itself it will be automatically linked.
     labels:
       defaults:
         description: Description

--- a/spec/features/create_publication_spec.rb
+++ b/spec/features/create_publication_spec.rb
@@ -1,6 +1,7 @@
 # Generated via
 #  `rails generate hyrax:work Publication`
 require 'rails_helper'
+
 include Warden::Test::Helpers
 
 RSpec.feature 'Create a Publication', js: true do
@@ -48,6 +49,7 @@ RSpec.feature 'Create a Publication', js: true do
       fill_in 'Subject', with: 'Subject'
       fill_in 'Table of Contents', with: 'Table of Contents'
       fill_in 'Temporal', with: 'Temporal'
+      fill_in 'Related URL', with: '<http://curationexperts.com>'
 
       click_link "Files"
 
@@ -85,6 +87,7 @@ RSpec.feature 'Create a Publication', js: true do
       expect(page).to have_content('Table of Contents')
       expect(page).to have_content('Temporal')
       expect(page).to have_content('Title')
+      expect(page).to have_link('http://curationexperts.com')
     end
   end
 end

--- a/spec/lib/rdf/markdown/literal_spec.rb
+++ b/spec/lib/rdf/markdown/literal_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe RDF::Markdown::Literal do
+  let(:literal) { described_class.new(value) }
+  let(:literal_id) { literal.id }
+  let(:literal_value) { literal.value }
+  let(:value) { 'test' }
+  let(:datatype) { described_class.new(value).datatype.to_s }
+  let(:markdown_datatype) { "http://ns.ontowiki.net/SysOnt/Markdown" }
+
+  describe '#id' do
+    it 'returns the value as id' do
+      expect(literal_id).to eq(value)
+    end
+  end
+
+  describe '#find' do
+    it 'returns the literal when searching by the value' do
+      expect(literal_value).to eq(value)
+    end
+  end
+
+  describe '#datatype' do
+    it 'returns a markdown datatype' do
+      expect(datatype).to eq(markdown_datatype)
+    end
+  end
+end


### PR DESCRIPTION
This commit adds an attribute renderer that will
render markdown content that is entered in the
Related URL field. The content is saved as an
RDF::Markdown::Literal in Fedora.

Closes #134