### PR TITLE
Add attributes to presenters

### DIFF
--- a/app/presenters/hyrax/conference_proceeding_presenter.rb
+++ b/app/presenters/hyrax/conference_proceeding_presenter.rb
@@ -3,5 +3,7 @@
 module Hyrax
   class ConferenceProceedingPresenter < Hyrax::WorkShowPresenter
     include ::Hyrax::HasZip
+
+    Attributes.to_a.each { |term| delegate term, to: :solr_document }
   end
 end

--- a/app/presenters/hyrax/data_set_presenter.rb
+++ b/app/presenters/hyrax/data_set_presenter.rb
@@ -3,5 +3,7 @@
 module Hyrax
   class DataSetPresenter < Hyrax::WorkShowPresenter
     include ::Hyrax::HasZip
+
+    Attributes.to_a.each { |term| delegate term, to: :solr_document }
   end
 end


### PR DESCRIPTION
The attributes were only included in the `Publication` presenter.
This commit adds them to the two other work types.