### PR TITLE
Cleanup old zip files. Story #126.  Fixed problem where updating crontab failed because Rails.root didn't interpolate

### DIFF
--- a/README_work_zips.md
+++ b/README_work_zips.md
@@ -30,6 +30,8 @@ If you change the directory where the zip files are stored, you probably also wa
 
 [Config for Scheduled Tasks](config/schedule.rb)
 
+[Rake task that does the cleanup](lib/tasks/cleanup.rake)
+
 ### More Info
 
 See the comments in [the WorkZip class](app/models/work_zip.rb)

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,6 +19,7 @@
 # end
 
 # Learn more: http://github.com/javan/whenever
+
 # Delete blacklight saved searches
 every :day, at: '11:55pm' do
   rake 'blacklight:delete_old_searches[1]'
@@ -29,7 +30,7 @@ every :day, at: '1:00am' do
   command '/usr/bin/find /tmp -type f -mtime +7 -user deploy -execdir /bin/rm – {} \\;'
 end
 
-# Remove files in default directory for storing zipped download files owned by the deploy user that are older than 7 days
-every :day, at: '1:00am' do
-  command "/usr/bin/find #{Rails.root.join('tmp', 'zip_exports')} -type f -mtime +7 -user deploy -execdir /bin/rm – {} \\;" # rubocop:disable Rails/FilePath
+# Remove older zip files from bulk downloads
+every :day, at: '1:05am' do
+  rake 'cleanup:zips'
 end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,0 +1,14 @@
+namespace :cleanup do
+  desc 'Clean up old zip files for bulk downloads'
+  task zips: :environment do
+    dir = WorkZip.new.path_root
+    zip_files = File.join(dir, '*.zip')
+    age = 7.days.ago
+
+    Dir.glob(zip_files) do |file|
+      next if File.mtime(file) > age
+      # puts "deleting: #{file}"
+      File.delete(file)
+    end
+  end
+end


### PR DESCRIPTION
This will find the files whether you set the environment variable for the zip directory or you just use the default directory.