### PR TITLE
Add a stage for DCE's qa server

### DIFF
--- a/config/deploy/ce_qa.rb
+++ b/config/deploy/ce_qa.rb
@@ -1,0 +1,4 @@
+# deploys to dce qa
+set :stage, :ce_qa
+set :rails_env, 'production'
+server 'cypripedium-qa.curationexperts.com', user: 'deploy', roles: [:web, :app, :db]


### PR DESCRIPTION
This adds a stage that can be used to deploy
to DCE's server: http://cypripedium-qa.curationexperts.com/