### PR TITLE
Initial models for bagging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,7 @@ git_source(:github) do |repo_name|
 end
 
 gem 'active_job_status', '~> 1.2.1'
-gem 'redis-activesupport'
-
+gem 'bagit'
 gem 'bixby'
 gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 gem 'capistrano'
@@ -21,6 +20,7 @@ gem 'hydra-role-management'
 gem 'nokogiri', '>=1.8.2'
 gem 'parser', '< 2.5'
 gem 'pg', '~> 0.18'
+gem 'redis-activesupport'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.4'
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,9 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
+    bagit (0.4.2)
+      docopt (~> 0.5.0)
+      validatable (~> 1.6)
     bcp47 (0.3.3)
       i18n
     bcrypt (3.1.12)
@@ -211,6 +214,7 @@ GEM
       devise
     diff-lcs (1.3)
     docile (1.3.1)
+    docopt (0.5.0)
     dropbox_api (0.1.12)
       faraday (~> 0.9, ~> 0.8)
       oauth2 (~> 1.1)
@@ -809,6 +813,7 @@ GEM
     uglifier (4.1.19)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.4.0)
+    validatable (1.6.7)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.7.0)
@@ -831,6 +836,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_job_status (~> 1.2.1)
+  bagit
   bixby
   byebug
   capistrano

--- a/app/models/bag.rb
+++ b/app/models/bag.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'bagit'
+require 'stringio'
+require 'rubygems/package'
+require 'fileutils'
+
+# A class for creating a tarred bag when given a work id
+class Bag
+  attr_reader :bag_path, :bag
+
+  # @param work_id [String]
+  # @param time_stamp [String]
+  def initialize(work_id:, time_stamp:)
+    @work_id = work_id
+    @time_stamp = time_stamp
+    @work_file_sets = ActiveFedora::Base.find(work_id).file_sets
+    @bag_path = Rails.root.join('tmp', 'bags', "#{@work_id}_#{@time_stamp}")
+    @bag = BagIt::Bag.new(@bag_path)
+  end
+
+  def create
+    @work_file_sets.each do |work_file_set|
+      work_file_set.files.each do |work_file|
+        @bag.add_file(work_file.file_name.first) do |io|
+          io.set_encoding Encoding::BINARY
+          io.write work_file.content
+        end
+      end
+    end
+    @bag.manifest!(algo: 'sha256')
+    tar
+    remove_bag
+  end
+
+  def tar
+    block_size = 1024 * 1000
+    tar_file = Rails.root.join('tmp', 'bags', "#{@work_id}_#{@time_stamp}.tar")
+    src = @bag_path.to_s
+
+    File.open tar_file, 'wb' do |open_tar_file|
+      Gem::Package::TarWriter.new open_tar_file do |tar|
+        Find.find *src do |file|
+          mode = File.stat(file).mode
+          size = File.stat(file).size
+          if File.directory? file
+            tar.mkdir file, mode
+          else
+            tar.add_file_simple file, mode, size do |tar_io|
+              File.open file, 'rb' do |rio|
+                while (buffer = rio.read(block_size))
+                  tar_io.write buffer
+                end
+              end
+            end
+          end
+        end
+      end
+    end # end File.open
+  end
+
+  def remove_bag
+    FileUtils.rm_rf(@bag.bag_dir)
+  end
+end

--- a/app/models/bulk_bag.rb
+++ b/app/models/bulk_bag.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# A class for creating multiple bags from a list of Work ids
+class BulkBag
+  # @param ids [Array<String>] an array of IDs (as strings) that will be bagged
+  def initialize(ids:)
+    @ids = ids
+  end
+
+  def create
+    @ids.each do |id|
+      bag = Bag.new(work_id: id, time_stamp: Time.now.to_i)
+      bag.create
+    end
+  end
+end

--- a/spec/models/bag_spec.rb
+++ b/spec/models/bag_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+require 'fileutils'
+
+RSpec.describe Bag, type: :model do
+  subject(:work_bag) { described_class.new(work_id: publication.id, time_stamp: time_stamp) }
+
+  let(:tar_size) { 104_448 }
+  let(:time_stamp) { 109_092 }
+  let(:file_path) { Rails.root.join('tmp', 'bags', publication.id) }
+
+  let(:pdf_file) do
+    File.open(file_fixture('pdf-sample.pdf')) { |file| create(:file_set, content: file) }
+  end
+
+  let(:image_file) do
+    File.open(file_fixture('sir_mordred.jpg')) { |file| create(:file_set, content: file) }
+  end
+
+  let(:publication) do
+    create(:publication, title: ['My Publication'], file_sets: [pdf_file, image_file])
+  end
+
+  describe '#create' do
+    before do
+      FileUtils.rm_rf(file_path)
+      FileUtils.mkdir(Rails.root.join('tmp', 'bags'))
+    end
+
+    after do
+      FileUtils.rm_rf(file_path)
+      FileUtils.rm_rf("#{file_path}.tar.gz")
+    end
+
+    context 'a work file attached files' do
+      it 'creates a bag with the files' do
+        work_bag.create
+
+        # Expect the tar file to be created
+        # and expect it to be the correct size
+        expect(File.exist?("#{work_bag.bag_path}.tar")).to eq true
+        expect(File.size("#{work_bag.bag_path}.tar")).to eq tar_size
+      end
+    end
+  end
+end

--- a/spec/models/bulk_bag_spec.rb
+++ b/spec/models/bulk_bag_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BulkBag do
+  let(:bulk_bag) { described_class.new(ids: ids) }
+  let(:bags_path) { Rails.root.join('tmp', 'bags') }
+  let(:pdf_file) do
+    File.open(file_fixture('pdf-sample.pdf')) { |file| create(:file_set, content: file) }
+  end
+
+  let(:image_file) do
+    File.open(file_fixture('sir_mordred.jpg')) { |file| create(:file_set, content: file) }
+  end
+
+  let(:publication) do
+    create(:publication, title: ['My Publication'], file_sets: [pdf_file, image_file])
+  end
+  let(:second_publication) do
+    create(:publication, title: ['My Publication 2'], file_sets: [pdf_file, image_file])
+  end
+
+  let(:ids) do
+    [publication.id, second_publication.id]
+  end
+
+  before do
+    FileUtils.rm_rf(bags_path) if File.directory?(bags_path)
+    FileUtils.mkdir(bags_path)
+  end
+
+  after do
+    FileUtils.rm_rf(bags_path) if File.directory?(bags_path)
+  end
+
+  it 'creates bags from a list of ids' do
+    bulk_bag.create
+    expect(Dir.entries(bags_path).length).to eq 4
+  end
+end


### PR DESCRIPTION
This commit contains a `Bag` and `BulkBag` class
that are used for creating individual bags
and for creating multiple bags from an array of ids.

The bags that are generated by `Bag` are tar
files. This is because they will eventually need
to be downloaded/transferred. tar files are less
complex than zip files and don't compress files.

We don't need compression because the Work contents
is going to be binary data (PDFs and images). DPN
and APTrust both require tarred bags.

https://wiki.aptrust.org/Bagging_specifications
https://wiki.duraspace.org/display/DPNC/BagIt+Specification++OLD

These will be used in a rake task in later work so
that they can be used from the command line.

Connected to #191