### PR TITLE
Server-side bag implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@ The Research Database is a digital repository designed for public discovery of t
 
 </td></tr>
 </table>
+
+## BagIt Functionality
+
+BagIt archives can be created from the command line using the bag rake task:
+
+`rake bag:create[publication1,publication2,publication3]`
+
+The bag will be located in the directory set by the `ENV['BAG_PATH']` environment
+variable. It will be named `mpls_fed_research.<time-stamp>.tar` (time stamp being a unix time stamp). The contents of the bag will consist of all the attached files in
+the specified publications. The created bag will use `sha256` to create checksums for
+the files.

--- a/app/jobs/bag_job.rb
+++ b/app/jobs/bag_job.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class BagJob < ActiveJobStatus::TrackableJob
+  def perform(work_ids:, time_stamp: Time.now.to_i)
+    bag = Bag.new(work_ids: work_ids, time_stamp: time_stamp)
+    bag.create
+  end
+end

--- a/app/models/bag.rb
+++ b/app/models/bag.rb
@@ -14,7 +14,7 @@ class Bag
   def initialize(work_ids:, time_stamp:)
     @work_ids = work_ids
     @time_stamp = time_stamp
-    @bag_path = Rails.root.join('tmp', 'bags', "mpls_fed_research.#{@time_stamp}")
+    @bag_path = Rails.application.config.bag_path.join("mpls_fed_research.#{@time_stamp}")
     @bag = BagIt::Bag.new(@bag_path)
   end
 
@@ -37,7 +37,7 @@ class Bag
 
   def tar
     block_size = 1024 * 1000
-    tar_file = Rails.root.join('tmp', 'bags', "mpls_fed_research.#{@time_stamp}.tar")
+    tar_file = Rails.application.config.bag_path.join("mpls_fed_research.#{@time_stamp}.tar")
     src = @bag_path.to_s
 
     File.open tar_file, 'wb' do |open_tar_file|

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.bag_path = ENV['BAG_PATH'] || Rails.root.join('tmp', 'bags')
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,6 +88,8 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.bag_path = ENV['BAG_PATH'] || Rails.root.join('opt', 'derivatives', 'bags')
 end
 
 Hyrax.config.derivatives_path = '/opt/derivatives'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  config.bag_path = config.bag_path = ENV['BAG_PATH'] || Rails.root.join('tmp', 'bags')
 end

--- a/lib/tasks/bag.rake
+++ b/lib/tasks/bag.rake
@@ -1,0 +1,9 @@
+namespace :bag do
+  desc "Create a bag from a list of Publication IDs"
+  task :create, [:work_ids] => :environment do |t, args|
+    work_ids = args[:work_ids]
+    extra_ids = args.extras
+    all_ids = [work_ids] | extra_ids
+    BagJob.perform_now(work_ids: all_ids)
+  end
+end

--- a/spec/jobs/bag_job_spec.rb
+++ b/spec/jobs/bag_job_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BagJob, type: :job do
+  let(:work_ids) { ['1', '2'] }
+  let(:file_path) { Rails.application.config.bag_path }
+
+  context 'running the job' do
+    it 'get queued' do
+      ActiveJob::Base.queue_adapter = :test
+      described_class.perform_later(work_ids: work_ids)
+      expect(described_class).to have_been_enqueued
+    end
+  end
+end

--- a/spec/models/bag_spec.rb
+++ b/spec/models/bag_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Bag, type: :model do
 
   let(:tar_size) { 202_752 }
   let(:time_stamp) { 109_092 }
-  let(:file_path) { Rails.root.join('tmp', 'bags') }
+  let(:file_path) { Rails.application.config.bag_path }
 
   let(:pdf_file) do
     File.open(file_fixture('pdf-sample.pdf')) { |file| create(:file_set, content: file) }
@@ -27,7 +27,7 @@ RSpec.describe Bag, type: :model do
   describe '#create' do
     before do
       FileUtils.rm_rf(file_path)
-      FileUtils.mkdir(Rails.root.join('tmp', 'bags'))
+      FileUtils.mkdir(Rails.application.config.bag_path)
     end
 
     after do


### PR DESCRIPTION
This uses the `Bag` class that
was introduced in a new bag job that
is used in a rake task for creating bags.

To use the rake task:

`bundle exec rake bag:create[work_id1, work_id2]`

This will create a bag containing the works that you
supply ids for.

They will be located in the path set by the
`Rails.application.config.bag_path` variable, which can be
manually set, or using the env varible: `ENV['BAG_PATH']`

Connected to #191