### PR TITLE
Add downloads for bags

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ The bag will be located in the directory set by the `ENV['BAG_PATH']` environmen
 variable. It will be named `mpls_fed_research.<time-stamp>.tar` (time stamp being a unix time stamp). The contents of the bag will consist of all the attached files in
 the specified publications. The created bag will use `sha256` to create checksums for
 the files.
+
+To download a bag that has been created you can visit the route: `/bag/mpls_fed_research.<time-stamp>.tar`.

--- a/app/controllers/bag_controller.rb
+++ b/app/controllers/bag_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class BagController < ApplicationController
+  def download
+    send_file Rails.application.config.bag_path + bag_params
+  end
+
+  private
+
+    def bag_params
+      params.require(:file_name)
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
 
   get  '/zip/:work_id', to: 'work_zips#download', as: 'download_zip'
   post '/zip/:work_id', to: 'work_zips#create', as: 'create_zip'
+  get '/bag/:file_name', to: 'bag#download'
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/controllers/bag_controller_spec.rb
+++ b/spec/controllers/bag_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+require 'fileutils'
+
+RSpec.describe BagController, type: :controller do
+  let(:bag_path) { Rails.application.config.bag_path }
+  let(:bag_file_path) { [Rails.application.config.bag_path, '/test.tar'].join }
+  before do
+    FileUtils.mkdir(bag_path)
+    FileUtils.touch(bag_file_path)
+  end
+
+  after do
+    FileUtils.rm_rf(bag_path)
+  end
+
+  describe "GET #download" do
+    it "returns http success" do
+      get :download, params: { file_name: 'test.tar' }
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
This adds the ability to download bags from the `/bag/:file_name`
route. The bag file will be sent as long as it is present in the
directory where bags are stored.

Connected to #193