### PR TITLE
Add a route to create a bag

### DIFF
--- a/app/controllers/bag_controller.rb
+++ b/app/controllers/bag_controller.rb
@@ -5,7 +5,15 @@ class BagController < ApplicationController
     send_file Rails.application.config.bag_path + bag_params
   end
 
+  def create
+    BagJob.perform_later(work_ids: create_params)
+  end
+
   private
+
+    def create_params
+      params.require(:work_ids)
+    end
 
     def bag_params
       params.require(:file_name)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,6 @@ Rails.application.routes.draw do
   get  '/zip/:work_id', to: 'work_zips#download', as: 'download_zip'
   post '/zip/:work_id', to: 'work_zips#create', as: 'create_zip'
   get '/bag/:file_name', to: 'bag#download'
-
+  post '/bag/create', to: 'bag#create'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/controllers/bag_controller_spec.rb
+++ b/spec/controllers/bag_controller_spec.rb
@@ -19,4 +19,11 @@ RSpec.describe BagController, type: :controller do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe "POST #create" do
+    it "returns http success" do
+      post :create, params: { work_ids: ['ids1'] }
+      expect(response).to have_http_status(:success)
+    end
+  end
 end


### PR DESCRIPTION
This commit adds a route and a controller
action to trigger the creation of a bag.

It is triggered by sending a `POST` request
to `/bag/create` with an array of work ids
in a `work_ids` parameter.

This will be used in the front-end to
trigger bag creation.

Connected to #188