### PR TITLE
Add a notification after bag creation

### DIFF
--- a/app/jobs/bag_job.rb
+++ b/app/jobs/bag_job.rb
@@ -1,8 +1,22 @@
 # frozen_string_literal: true
 
 class BagJob < ActiveJobStatus::TrackableJob
-  def perform(work_ids:, time_stamp: Time.now.to_i)
-    bag = Bag.new(work_ids: work_ids, time_stamp: time_stamp)
-    bag.create
+  after_perform :after_bag_creation
+
+  attr_reader :bag, :user
+
+  def perform(work_ids:, time_stamp: Time.now.to_i, user:)
+    @user = user
+    @bag = Bag.new(work_ids: work_ids, time_stamp: time_stamp)
+    @bag.create
   end
+
+  private
+
+    def after_bag_creation
+      bag_file_name = @bag.bag_path.split.last.to_s
+      @user.send_message(@user,
+                         "Your bag has been created and can be downloaded <a href='/bag/download/#{bag_file_name}'>here</a>.",
+                         "Your BagIt archive is ready")
+    end
 end

--- a/spec/features/bag_notification_spec.rb
+++ b/spec/features/bag_notification_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Recieve a notfication when creating a bag', js: false do
+  describe 'creating a notification when running a bag job' do
+    let(:work_ids) { [publication.id, publication2.id] }
+    let(:file_path) { Rails.application.config.bag_path }
+
+    let(:pdf_file) do
+      File.open(file_fixture('pdf-sample.pdf')) { |file| create(:file_set, content: file) }
+    end
+
+    let(:image_file) do
+      File.open(file_fixture('sir_mordred.jpg')) { |file| create(:file_set, content: file) }
+    end
+
+    let(:publication) do
+      create(:publication, title: ['My Publication'], file_sets: [pdf_file, image_file])
+    end
+
+    let(:publication2) do
+      create(:publication, title: ['My Publication 2'], file_sets: [pdf_file, image_file])
+    end
+
+    let(:user_attributes) do
+      { email: 'test@example.com' }
+    end
+    let(:user) do
+      User.new(user_attributes) { |u| u.save(validate: false) }
+    end
+
+    before do
+      AdminSet.find_or_create_default_admin_set_id
+      login_as user
+      FileUtils.rm_rf(file_path)
+      FileUtils.mkdir(Rails.application.config.bag_path)
+    end
+
+    after do
+      FileUtils.rm_rf(file_path)
+    end
+
+    it 'creates a notification' do
+      BagJob.perform_now(work_ids: work_ids, user: user)
+      visit '/notifications'
+      expect(page).to have_link('here')
+      expect(page).to have_content('bag')
+    end
+  end
+end

--- a/spec/jobs/bag_job_spec.rb
+++ b/spec/jobs/bag_job_spec.rb
@@ -3,13 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe BagJob, type: :job do
-  let(:work_ids) { ['1', '2'] }
+  let(:work_ids) { [1, 2] }
   let(:file_path) { Rails.application.config.bag_path }
+  let(:user) { FactoryBot.create(:admin) }
 
   context 'running the job' do
     it 'get queued' do
       ActiveJob::Base.queue_adapter = :test
-      described_class.perform_later(work_ids: work_ids)
+      described_class.perform_later(work_ids: work_ids, user: user)
       expect(described_class).to have_been_enqueued
     end
   end


### PR DESCRIPTION
This commit changes the bag job so that it will
send a notification containing a link to the bag
to the user who created the job, when the bag is
done being created.

Connected to #192