### PR TITLE
Switch to zip for bags

### DIFF
--- a/app/controllers/bag_controller.rb
+++ b/app/controllers/bag_controller.rb
@@ -2,7 +2,7 @@
 
 class BagController < ApplicationController
   def download
-    send_file("#{Rails.application.config.bag_path}/#{bag_params}.tar", type: 'application/x-tar', disposition: 'attachment')
+    send_file("#{Rails.application.config.bag_path}/#{bag_params}.zip", type: 'application/zip', disposition: 'attachment')
   end
 
   def create

--- a/spec/controllers/bag_controller_spec.rb
+++ b/spec/controllers/bag_controller_spec.rb
@@ -3,7 +3,7 @@ require 'fileutils'
 
 RSpec.describe BagController, type: :controller do
   let(:bag_path) { Rails.application.config.bag_path }
-  let(:bag_file_path) { [Rails.application.config.bag_path, '/test.tar'].join }
+  let(:bag_file_path) { [Rails.application.config.bag_path, '/test.zip'].join }
   before do
     FileUtils.mkdir(bag_path)
     FileUtils.touch(bag_file_path)

--- a/spec/models/bag_spec.rb
+++ b/spec/models/bag_spec.rb
@@ -3,8 +3,6 @@ require 'fileutils'
 
 RSpec.describe Bag, type: :model do
   subject(:work_bag) { described_class.new(work_ids: [publication.id, publication2.id], time_stamp: time_stamp) }
-
-  let(:tar_size) { 202_752 }
   let(:time_stamp) { 109_092 }
   let(:file_path) { Rails.application.config.bag_path }
 
@@ -37,7 +35,7 @@ RSpec.describe Bag, type: :model do
     context 'a work file attached files' do
       it 'creates a bag from the works' do
         work_bag.create
-        expect(File.size("#{work_bag.bag_path}.tar")).to eq tar_size
+        expect(File.exist?("#{work_bag.bag_path}.zip"))
       end
     end
   end


### PR DESCRIPTION
Preservica will only ingest bags that use
`zip` compressed files. This changes the bagit archives
that are exported to use `zip` instead of `tar`.

Connected to #191