### PR TITLE
Allow `data-turbolinks` attribute in views

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,4 +53,6 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.bag_path = ENV['BAG_PATH'] || Rails.root.join('tmp', 'bags')
+
+  config.action_view.sanitized_allowed_attributes = ['href', 'title', 'data-turbolinks']
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,6 +90,8 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.bag_path = ENV['BAG_PATH'] || '/tmp/bags'
+
+  config.action_view.sanitized_allowed_attributes = ['href', 'title', 'data-turbolinks']
 end
 
 Hyrax.config.derivatives_path = '/opt/derivatives'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,4 +40,6 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   config.bag_path = config.bag_path = ENV['BAG_PATH'] || Rails.root.join('tmp', 'bags')
+
+  config.action_view.sanitized_allowed_attributes = ['href', 'title', 'data-turbolinks']
 end


### PR DESCRIPTION
This configures the default html sanitizer to
allow `data-turbolinks`. Without this, links to
binary files do not display correctly.