### PR TITLE
Added date created sort, removed date uploaded sort. #208 and #210

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -262,8 +262,8 @@ class CatalogController < ApplicationController
     config.add_sort_field "title_ssi desc, score desc", label: "title \u25BC"
     config.add_sort_field "issue_number_ssi desc", label: "issue number \u25BC"
     config.add_sort_field "issue_number_ssi asc", label: "issue number \u25B2"
-    config.add_sort_field "#{uploaded_field} desc", label: "date uploaded \u25BC"
-    config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
+    config.add_sort_field "date_created_ssi desc", label: "date published \u25BC"
+    config.add_sort_field "date_created_ssi asc", label: "date published \u25B2"
     config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
     config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"
 

--- a/app/indexers/indexes_metadata.rb
+++ b/app/indexers/indexes_metadata.rb
@@ -2,6 +2,7 @@ module IndexesMetadata
   def generate_solr_document
     super.tap do |solr_doc|
       solr_doc['title_ssi'] = object.title.first
+      solr_doc['date_created_ssi'] = object.date_created.first
     end
   end
 end

--- a/spec/indexers/publication_indexer_spec.rb
+++ b/spec/indexers/publication_indexer_spec.rb
@@ -4,13 +4,14 @@ require 'rails_helper'
 RSpec.describe PublicationIndexer do
   let(:indexer) { described_class.new(publication) }
   let(:publication) { Publication.new(attrs) }
-  let(:attrs) { { title: ['My Title'] } }
+  let(:attrs) { { title: ['My Title'], date_created: ['1970-04'] } }
 
   describe '#generate_solr_document' do
     let(:solr_doc) { indexer.generate_solr_document }
 
-    it 'indexes a sortable title' do
+    it 'indexes a sortable title and date created' do
       expect(solr_doc['title_ssi']).to eq 'My Title'
+      expect(solr_doc['date_created_ssi']).to eq '1970-04'
     end
   end
 end


### PR DESCRIPTION
We don't enter dates in UTC format in the date created field, so instead of indexing with _dtsi, I used _ssi. For issues #208 and #210