### PR TITLE
Give more unique bag notifications

### DIFF
--- a/app/jobs/bag_job.rb
+++ b/app/jobs/bag_job.rb
@@ -14,9 +14,13 @@ class BagJob < ActiveJobStatus::TrackableJob
   private
 
     def after_bag_creation
-      bag_file_name = @bag.bag_path.split('/').last.to_s
-      @user.send_message(@user,
-                         "Your bag has been created and can be downloaded <a data-turbolinks='false' href='/bag/#{bag_file_name}'>here</a>.",
-                         "Your BagIt archive is ready")
+      @user.send_message(@user, render_message(bag_file_name: @bag.bag_path.split('/').last.to_s, bag_files: @bag.bag.paths), "Your BagIt archive is ready")
+      @bag.remove_bag
+    end
+
+    def render_message(bag_file_name:, bag_files:)
+      ActionView::Base.new(Rails.configuration.paths['app/views']).render file: 'bag/_notification.html.erb',
+                                                                          locals: { bag_file_name: bag_file_name,
+                                                                                    bag_files: bag_files }
     end
 end

--- a/app/models/bag.rb
+++ b/app/models/bag.rb
@@ -35,7 +35,6 @@ class Bag
     end
     @bag.manifest!(algo: 'sha256')
     zip
-    remove_bag
   end
 
   def zip

--- a/app/views/bag/_notification.html.erb
+++ b/app/views/bag/_notification.html.erb
@@ -1,0 +1,10 @@
+<div>
+Your bag has been created and can be downloaded: <a data-turbolinks='false' href='/bag/<%= bag_file_name %>'><%= bag_file_name %></a>
+</div>
+<div>This bag contains the following files:
+  <ul>
+  <% bag_files.each do |bag_file| %>
+    <li><%= bag_file %></li>
+  <% end %>
+  </ul>
+</div>

--- a/spec/features/bag_notification_spec.rb
+++ b/spec/features/bag_notification_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature 'Recieve a notfication when creating a bag', js: true do
     it 'creates a notification' do
       BagJob.perform_now(work_ids: work_ids, user: user)
       visit '/notifications'
-      expect(page).to have_link('here')
+      expect(page).to have_content('has been created')
       expect(page).to have_content('bag')
     end
 


### PR DESCRIPTION
This commit changes the bag notification messages
to contain the file name of the bag in the link and
gives a list of the files in the bag.

This is formatted as an html list.

Connected to #238