### PR TITLE
Create bag storage dir if missing

### DIFF
--- a/app/models/bag.rb
+++ b/app/models/bag.rb
@@ -17,6 +17,7 @@ class Bag
     @work_ids = work_ids
     @time_stamp = time_stamp
     @bag_path = "#{Rails.application.config.bag_path}/mpls_fed_research_#{@time_stamp}"
+    create_bag_storage_dir
     @bag = BagIt::Bag.new(@bag_path)
   end
 
@@ -38,19 +39,25 @@ class Bag
     remove_bag
   end
 
-  def zip
-    zip_name = "#{@bag_path}.zip"
-    src = @bag_path.to_s
-
-    Zip::File.open(zip_name, Zip::File::CREATE) do |zip_file|
-      ::Find.find(*src) do |file|
-        relative_path = file.sub(@bag_path.to_s, "mpls_fed_research_#{@time_stamp}")
-        zip_file.add(relative_path, File.new(file))
-      end
-    end
-  end
-
   def remove_bag
     FileUtils.rm_rf(@bag.bag_dir)
   end
+
+  private
+
+    def create_bag_storage_dir
+      FileUtils.mkdir(Rails.application.config.bag_path) unless File.exist?(Rails.application.config.bag_path)
+    end
+
+    def zip
+      zip_name = "#{@bag_path}.zip"
+      src = @bag_path.to_s
+
+      Zip::File.open(zip_name, Zip::File::CREATE) do |zip_file|
+        ::Find.find(*src) do |file|
+          relative_path = file.sub(@bag_path.to_s, "mpls_fed_research_#{@time_stamp}")
+          zip_file.add(relative_path, File.new(file))
+        end
+      end
+    end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,7 +89,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.bag_path = ENV['BAG_PATH'] || '/tmp/bags'
+  config.bag_path = ENV['BAG_PATH'] || '/opt/derivatives/bags'
 
   config.action_view.sanitized_allowed_attributes = ['href', 'title', 'data-turbolinks']
 end

--- a/spec/models/bag_spec.rb
+++ b/spec/models/bag_spec.rb
@@ -23,11 +23,6 @@ RSpec.describe Bag, type: :model do
   end
 
   describe '#create' do
-    before do
-      FileUtils.rm_rf(file_path)
-      FileUtils.mkdir(Rails.application.config.bag_path)
-    end
-
     after do
       FileUtils.rm_rf(file_path)
     end


### PR DESCRIPTION
This commit adds a method to create the directory
where bags will be stored if it hasn't already been
created.

The directory is `/opt/derivatives/bags` in the
production environment by default. It could also be
set with the `BAG_PATH` env variable.

Connected to #224