### PR TITLE
Add the first bag name and a count to notification

### DIFF
--- a/app/views/bag/_notification.html.erb
+++ b/app/views/bag/_notification.html.erb
@@ -1,10 +1,3 @@
 <div>
-Your bag has been created and can be downloaded: <a data-turbolinks='false' href='/bag/<%= bag_file_name %>'><%= bag_file_name %></a>
-</div>
-<div>This bag contains the following files:
-  <ul>
-  <% bag_files.each do |bag_file| %>
-    <li><%= bag_file %></li>
-  <% end %>
-  </ul>
+  Your bag containing <%= bag_files.first %> and <%= bag_files.size - 1 %> additional files has been created and can be downloaded: <a data-turbolinks='false' href='/bag/<%= bag_file_name %>'><%= bag_file_name %></a>
 </div>


### PR DESCRIPTION
This changes the notification to include the first file
in the bag and then a count of all the rest of the files.

Connected to #238