### PR TITLE
Communicate Bagit export error to user

### DIFF
--- a/app/jobs/bag_job.rb
+++ b/app/jobs/bag_job.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class BagJob < ActiveJobStatus::TrackableJob
+  rescue_from(StandardError) do |exception|
+    @user.send_message(@user, render_error_message(error: exception), "Error creating your BagIt Archive")
+  end
+
   after_perform :after_bag_creation
 
   attr_reader :bag, :user
@@ -22,5 +26,10 @@ class BagJob < ActiveJobStatus::TrackableJob
       ActionView::Base.new(Rails.configuration.paths['app/views']).render file: 'bag/_notification.html.erb',
                                                                           locals: { bag_file_name: bag_file_name,
                                                                                     bag_files: bag_files }
+    end
+
+    def render_error_message(error:)
+      ActionView::Base.new(Rails.configuration.paths['app/views']).render file: 'bag/_error_notification.html.erb',
+                                                                          locals: { error: error }
     end
 end

--- a/app/views/bag/_error_notification.html.erb
+++ b/app/views/bag/_error_notification.html.erb
@@ -1,0 +1,4 @@
+There was an error starting your bag job:
+<pre>
+<%= error %>
+</pre>

--- a/spec/features/bag_error_notification_spec.rb
+++ b/spec/features/bag_error_notification_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+include Warden::Test::Helpers
+
+# This spec should not create the directory where the bags
+# are stored so that the bagging job will fail early.
+# right now the directory will be created if the parent
+# directory exists and there are permissions on the directory
+# this spec creates a situation where the bag directory can't be
+# created.
+RSpec.feature 'Recieve an error notfication when creating a bag', js: true do
+  describe 'creating a notification when running a bag job' do
+    let(:work_ids) { [1, 2] }
+    let(:user) { FactoryBot.create(:admin) }
+
+    before do
+      AdminSet.find_or_create_default_admin_set_id
+      login_as user
+    end
+
+    it 'creates an error notification' do
+      BagJob.perform_now(work_ids: work_ids, user: user)
+      visit '/notifications'
+      expect(page).to have_content('error')
+    end
+  end
+end


### PR DESCRIPTION
This commit uses the ActiveJob's `rescue_from`
callback to send an error message to the user
as a notification.

Connected to #211