### PR TITLE
Change BagUI init to be triggered by Turbolinks load

### DIFF
--- a/app/views/hyrax/my/works/_batch_actions.html.erb
+++ b/app/views/hyrax/my/works/_batch_actions.html.erb
@@ -3,9 +3,9 @@
 
   <div class="batch-toggle">
     <script>
-      document.addEventListener("DOMContentLoaded", function(event) {
-        BagUI.init()
-      })
+     document.addEventListener('turbolinks:load', function(event) {
+       BagUI.init()
+     })
     </script>
     <%= button_tag "Add to Bag", class: 'btn btn-primary submits-batches submits-ids-for-bags' %>
 


### PR DESCRIPTION
This change the event that initializes the BagUI features
from page load to `turbolinks:load` so that it will
stay init'ed across Turbolinks page loads.

Connected to #254