### PR TITLE
Add RDF XML to Bag

### DIFF
--- a/app/lib/rdf_xml_service.rb
+++ b/app/lib/rdf_xml_service.rb
@@ -1,0 +1,11 @@
+class RdfXmlService
+  attr_reader :graph_exporter
+  def initialize(work_id:)
+    solr_doc = SolrDocument.find(work_id)
+    @graph_exporter = ::Hyrax::GraphExporter.new(solr_doc, RequestShim.new({}))
+  end
+
+  def xml
+    @graph_exporter.fetch.dump(:rdf)
+  end
+end

--- a/app/lib/request_shim.rb
+++ b/app/lib/request_shim.rb
@@ -1,0 +1,5 @@
+class RequestShim < ActionDispatch::Request
+  def host
+    Rails.application.config.rdf_uri
+  end
+end

--- a/app/models/bag.rb
+++ b/app/models/bag.rb
@@ -23,6 +23,9 @@ class Bag
 
   def create
     @work_ids.each do |work_id|
+      @bag.add_file("#{work_id}/#{work_id}.xml") do |io|
+        io.write xml(work_id: work_id)
+      end
       @work_file_sets = ActiveFedora::Base.find(work_id).file_sets
       @work_file_sets.each do |work_file_set|
         work_file_set.files.each do |work_file|
@@ -58,5 +61,10 @@ class Bag
           zip_file.add(relative_path, File.new(file))
         end
       end
+    end
+
+    def xml(work_id:)
+      rdf_xml_service = RdfXmlService.new(work_id: work_id)
+      rdf_xml_service.xml
     end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,4 +55,6 @@ Rails.application.configure do
   config.bag_path = ENV['BAG_PATH'] || Rails.root.join('tmp', 'bags')
 
   config.action_view.sanitized_allowed_attributes = ['href', 'title', 'data-turbolinks']
+
+  config.rdf_uri = 'https://researchdatabase.minneapolisfed.org'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,6 +92,8 @@ Rails.application.configure do
   config.bag_path = ENV['BAG_PATH'] || '/opt/derivatives/bags'
 
   config.action_view.sanitized_allowed_attributes = ['href', 'title', 'data-turbolinks']
+
+  config.rdf_uri = 'https://researchdatabase.minneapolisfed.org'
 end
 
 Hyrax.config.derivatives_path = '/opt/derivatives'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,4 +42,6 @@ Rails.application.configure do
   config.bag_path = config.bag_path = ENV['BAG_PATH'] || Rails.root.join('tmp', 'bags')
 
   config.action_view.sanitized_allowed_attributes = ['href', 'title', 'data-turbolinks']
+
+  config.rdf_uri = 'https://researchdatabase.minneapolisfed.org'
 end

--- a/spec/jobs/bag_job_spec.rb
+++ b/spec/jobs/bag_job_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe BagJob, type: :job do
   let(:work_ids) { [1, 2] }
   let(:file_path) { Rails.application.config.bag_path }
   let(:user) { FactoryBot.create(:admin) }
+  let(:request) { ActionDispatch::Request.new(host: 'http://localhost:3000') }
 
   context 'running the job' do
     it 'get queued' do
       ActiveJob::Base.queue_adapter = :test
-      described_class.perform_later(work_ids: work_ids, user: user)
+      described_class.perform_later(work_ids: work_ids, user: user, request: request.as_json)
       expect(described_class).to have_been_enqueued
     end
   end

--- a/spec/lib/rdf_xml_service_spec.rb
+++ b/spec/lib/rdf_xml_service_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+require 'nokogiri'
+
+RSpec.describe RdfXmlService, type: :model do
+  subject(:rdf_xml_service) { described_class.new(work_id: publication.id) }
+
+  let(:pdf_file) do
+    File.open(file_fixture('pdf-sample.pdf')) { |file| create(:file_set, content: file) }
+  end
+
+  let(:image_file) do
+    File.open(file_fixture('sir_mordred.jpg')) { |file| create(:file_set, content: file) }
+  end
+
+  let(:publication) do
+    create(:publication, title: ['My Publication'], file_sets: [pdf_file, image_file])
+  end
+
+  describe '#xml' do
+    it 'returns a valid rdf+xml version of the metadata for a publication' do
+      doc = Nokogiri::XML(rdf_xml_service.xml)
+      expect(doc.errors).to eq([])
+      expect(doc.to_s).to match(/My Publication/)
+    end
+  end
+end

--- a/spec/lib/request_shim_spec.rb
+++ b/spec/lib/request_shim_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe RequestShim do
+  let(:request_shim) { described_class.new({}) }
+
+  it 'returns the host' do
+    expect(request_shim.host).to eq(Rails.application.config.rdf_uri)
+  end
+end


### PR DESCRIPTION
This commit includes an RDF XML service
that is used to get metadata for a work
and then place that in the bag.

The RDF service requires the URI host to be
set in Rails configuration. By default this is
set to the current URL for the MPLS Fed Research
Database.

Connected to #265