### PR TITLE
Rake task to reindex all work and collection records

### DIFF
--- a/lib/tasks/reindex.rake
+++ b/lib/tasks/reindex.rake
@@ -1,11 +1,43 @@
-desc 'Re-index solr records for cypripedium works'
+# Note:  This re-indexing tasks uses solr queries to
+# determine which records to re-index.  That means
+# that you can only use it to re-index solr records
+# that already exist.  So, for example, it can't be
+# used to repopulate the solr records after a clean.
+desc 'Re-index solr records for cypripedium works & collections'
 task reindex: :environment do
-  work_classes = Hyrax.config.curation_concerns
-  work_classes.each do |work_class|
-    puts "Re-indexing #{work_class} records"
-    work_class.all.each do |record|
+  $stdout.sync = true # Flush output immediately
+
+  start_time = Time.zone.now.localtime
+  puts "Re-index started at: #{start_time}"
+
+  models_to_reindex = [::Collection] + Hyrax.config.curation_concerns
+  models_to_reindex.each do |klass|
+    rows = klass.count
+    puts "Re-indexing #{klass.count} #{klass} records: #{Time.zone.now.localtime}"
+
+    id_list(klass, rows).each do |id|
+      next unless ActiveFedora::Base.exists?(id)
+      record = ActiveFedora::Base.find(id)
       record.update_index
     end
   end
-  puts "Re-index completed"
+
+  end_time = Time.zone.now.localtime
+  puts "Re-index finished at: #{end_time}"
+  printf "Re-index finished in: %0.1f minutes \n", time_in_minutes(start_time, end_time)
+end
+
+def solr
+  Blacklight.default_index.connection
+end
+
+# Get the list of IDs from the query results:
+def id_list(model, rows)
+  query = { params: { q: "has_model_ssim:#{model}", fl: "id", rows: rows } }
+  results = solr.select(query)
+  results['response']['docs'].flat_map(&:values)
+end
+
+def time_in_minutes(start_time, end_time)
+  (end_time - start_time) / 60.0
 end


### PR DESCRIPTION
Connected to #256

* Uses a solr query to find a list of IDs to reindex.

* Re-indexing is batched by model.

* Added Collection records to the list of models to reindex.

* Added timestamps to print statements so user will have a better sense
of how far along the task is.