### PR TITLE
Remove temporary bag when retrying job

### DIFF
--- a/app/jobs/bag_job.rb
+++ b/app/jobs/bag_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class BagJob < ActiveJobStatus::TrackableJob
   rescue_from(StandardError) do |exception|
+    @bag.remove if @bag
     @user.send_message(@user, render_error_message(error: exception), "Error creating your BagIt Archive")
   end
 


### PR DESCRIPTION
This will remove the working bag when recovering
from a bagging job error. If this isn't removed
it could cause problems when trying to create
the bag again.

Connected to #266