### PR TITLE
Change uglifier settings in prod env

### DIFF
--- a/app/assets/javascripts/bag/bag_button.js
+++ b/app/assets/javascripts/bag/bag_button.js
@@ -5,7 +5,7 @@ var bagButton = {
     if (submitIdsForBagButton) {
       submitIdsForBagButton.addEventListener('click', function (event) {
         var checkedWorks = []
-        document.querySelectorAll("[name='batch_document_ids[]']").forEach((el) => { if (el.checked) { checkedWorks.push(el.value) } })
+        document.querySelectorAll("[name='batch_document_ids[]']").forEach(function (el) { if (el.checked) { checkedWorks.push(el.value) } })
         bagButton.postBagRequest(checkedWorks, options)
         event.stopPropagation()
       }, false)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,7 +24,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
+  config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
I changed this earlier because an error
was ocurring when I tried to deploy. It
seems that when using this setting, the
JS isn't compatible with IE11

This removes the short
function syntax,`()=>`,  that
was used in the `bag_button` bag file
that was trigger this error when deploying.

Connected to #278