### PR TITLE
Change bag click event initialization

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,7 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= 
+//=
 //= require turbolinks
 //
 // Required by Blacklight
@@ -23,3 +23,5 @@
 //= require_tree .
 //= require hyrax
 
+bagButton.bindClick({'compression': 'zip'})
+bagButton.bindClick({'compression': 'tar'})

--- a/app/assets/javascripts/bag/bag_button.js
+++ b/app/assets/javascripts/bag/bag_button.js
@@ -1,17 +1,19 @@
 var bagButton = {
-  init: function (options) {
-    var submitIdsForBagButton = document.querySelector('.submits-ids-for-' + options.compression + '-bag')
+  bindClick: function (options) {
+    var buttonSelector = '.submits-ids-for-' + options.compression + '-bag'
 
-    if (submitIdsForBagButton) {
-      submitIdsForBagButton.addEventListener('click', function (event) {
-        var checkedWorks = []
-        document.querySelectorAll("[name='batch_document_ids[]']").forEach(function (el) { if (el.checked) { checkedWorks.push(el.value) } })
-        bagButton.postBagRequest(checkedWorks, options)
-        event.stopPropagation()
-      }, false)
-    }
+    $(document).off('click', buttonSelector, function () {}).on('click', buttonSelector, function () {
+      var checkedWorks = []
+      $("[name='batch_document_ids[]']").each(function (index, el) {
+        if (el.checked) { checkedWorks.push(el.value) }
+      })
+      bagButton.postBagRequest(checkedWorks, options)
+    })
   },
   postBagRequest: function (workIds, options) {
-    $.post('/bag/create', { 'work_ids': workIds, 'compression': options.compression }, function (response) {})
+    if (workIds.length > 0) {
+      $.post('/bag/create', { 'work_ids': workIds, 'compression': options.compression }, function (response) {
+      })
+    }
   }
 }

--- a/app/assets/javascripts/bag_ui.js
+++ b/app/assets/javascripts/bag_ui.js
@@ -1,6 +1,0 @@
-var bagUI = {
-  init: function () {
-    bagButton.init({'compression': 'zip'})
-    bagButton.init({'compression': 'tar'})
-  }
-}

--- a/app/views/hyrax/my/works/_batch_actions.html.erb
+++ b/app/views/hyrax/my/works/_batch_actions.html.erb
@@ -1,14 +1,10 @@
 <div class="batch-info">
   <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>
 
-  <div class="batch-toggle">
-    <script>
-     document.addEventListener('turbolinks:load', function(event) {
-       bagUI.init()
-     })
-    </script>
-    <%= button_tag "Add to Zip Bag", class: 'btn btn-primary submits-batches submits-ids-for-zip-bag' %>
-    <%= button_tag "Add to Tar Bag", class: 'btn btn-primary submits-batches submits-ids-for-tar-bag' %>
+  <div class="batch-toggle" data-turbolinks="false">
+    <%= button_tag "Add to Zip Bag", data: {turbolinks: false}, class: 'btn btn-primary e submits-batches submits-ids-for-zip-bag' %>
+    <%= button_tag "Add to Tar Bag", data: {turbolinks: false}, class: 'btn btn-primary submits-batches submits-ids-for-tar-bag' %>
+
 
     <% session[:batch_edit_state] = "on" %>
     <div class="button_to-inline">
@@ -16,7 +12,7 @@
     </div>
     <%= batch_delete %>
     <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
-        class: 'btn btn-primary submits-batches submits-batches-add',
-        data: { toggle: "modal", target: "#collection-list-container" } %>
+    class: 'btn btn-primary submits-batches submits-batches-add',
+      data: { toggle: "modal", target: "#collection-list-container" } %>
   </div>
 </div>

--- a/spec/features/bag_export_spec.rb
+++ b/spec/features/bag_export_spec.rb
@@ -40,6 +40,9 @@ RSpec.feature 'Bagit export:', js: true do
       check "batch_document_#{publication.id}"
       click_on 'Add to Zip Bag'
 
+      # Should redirect to notifications page
+      expect(page).to have_current_path(Hyrax::Engine.routes.url_helpers.notifications_path(locale: I18n.locale))
+
       # Correct background job should queue
       expect(BagJob).to have_been_enqueued.with(job_params).exactly(:once)
     end

--- a/spec/features/bag_export_spec.rb
+++ b/spec/features/bag_export_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Bagit export:', js: true do
+  let(:admin_user) { FactoryBot.create(:admin) }
+
+  before do
+    DatabaseCleaner.clean_with(:truncation)
+    ActiveFedora::Cleaner.clean!
+    AdminSet.find_or_create_default_admin_set_id
+
+    login_as admin_user
+  end
+
+  let(:publication) { create(:publication, title: ['Pub XYZ']) }
+  let(:data_set) { create(:dataset, title: ['DS XYZ']) }
+
+  context 'exporting a bag' do
+    let(:job_params) do
+      { work_ids: [publication.id],
+        user: admin_user,
+        compression: 'zip' }
+    end
+
+    before do
+      ActiveJob::Base.queue_adapter = :test
+      [publication, data_set] # Create the records
+    end
+
+    it 'queues the bagit job' do
+      visit Hyrax::Engine.routes.url_helpers.my_works_path
+
+      # Click 'All Works' tab to trigger turbolinks
+      click_on 'All Works'
+      expect(page).to have_link(publication.title.first)
+      expect(page).to have_link(data_set.title.first)
+
+      # Select one of the records for bag export
+      check "batch_document_#{publication.id}"
+      click_on 'Add to Zip Bag'
+
+      # Correct background job should queue
+      expect(BagJob).to have_been_enqueued.with(job_params).exactly(:once)
+    end
+  end
+end


### PR DESCRIPTION
This changes the click behavior of the
bag buttons so that they only post once.

To do this I converted some of the plain JS
to jQuery and moved the button initialization
to the `application.js` file so that it is
not re-initialized when Turbolinks is reloaded.