### PR TITLE
Change notification text for bag creation

### DIFF
--- a/app/jobs/bag_job.rb
+++ b/app/jobs/bag_job.rb
@@ -31,14 +31,16 @@ class BagJob < ActiveJobStatus::TrackableJob
 
     def after_bag_creation
       @user.send_message(@user, render_message(bag_file_name: @bag.bag_path.split('/').last.to_s,
-                                               bag_files: @bag.bag.paths, bag_format: @compression), "Your BagIt archive is ready")
+                                               bag_files: @bag.bag.paths, bag_format: @compression,
+                                               work_count: @bag.work_count), "Your BagIt archive is ready")
       @bag.remove
     end
 
-    def render_message(bag_file_name:, bag_files:, bag_format:)
+    def render_message(bag_file_name:, bag_files:, bag_format:, work_count:)
       ActionView::Base.new(Rails.configuration.paths['app/views']).render file: 'bag/_notification.html.erb',
                                                                           locals: { bag_file_name: bag_file_name,
-                                                                                    bag_files: bag_files, bag_file_format: bag_format }
+                                                                                    bag_files: bag_files, bag_file_format: bag_format,
+                                                                                    work_count: work_count }
     end
 
     def render_error_message(error:)

--- a/app/lib/hyrax/work_bag.rb
+++ b/app/lib/hyrax/work_bag.rb
@@ -32,6 +32,10 @@ module Hyrax
       raise 'Not yet implemented'
     end
 
+    def work_count
+      Set.new(@bag.paths.map { |path| path.split('/')[0] }).length
+    end
+
     private
 
       def create_bag_storage_dir

--- a/app/views/bag/_notification.html.erb
+++ b/app/views/bag/_notification.html.erb
@@ -1,3 +1,3 @@
 <div>
-  Your bag containing <%= bag_files.first %> and <%= bag_files.size - 1 %> additional files has been created and can be downloaded: <a data-turbolinks='false' href='/bag/<%= bag_file_name %>.<%= bag_file_format %>'><%= bag_file_name %>.<%= bag_file_format %></a>
+  Your bag containing <%= work_count %> <%= 'work'.pluralize(work_count) %>, including <%= bag_files.first %>, is available for download at <a data-turbolinks='false' href='/bag/<%= bag_file_name %>.<%= bag_file_format %>'><%= bag_file_name %>.<%= bag_file_format %></a>
 </div>

--- a/spec/features/bag_notification_spec.rb
+++ b/spec/features/bag_notification_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'Recieve a notfication when creating a bag', js: true do
     it 'creates a notification' do
       BagJob.perform_now(work_ids: work_ids, user: user, compression: 'tar')
       visit '/notifications'
-      expect(page).to have_content('has been created')
+      expect(page).to have_content('available for download')
       expect(page).to have_content('bag')
     end
   end

--- a/spec/lib/hyrax/zip_bag_spec.rb
+++ b/spec/lib/hyrax/zip_bag_spec.rb
@@ -22,12 +22,23 @@ RSpec.describe Hyrax::ZipBag, type: :model do
     create(:publication, title: ['My Publication 2'], file_sets: [pdf_file, image_file])
   end
 
+  describe '#work_count' do
+    after do
+      FileUtils.rm_rf(file_path)
+    end
+
+    it 'can return the number of works in the bag' do
+      work_bag.create
+      expect(work_bag.work_count).to eq(2)
+    end
+  end
+
   describe '#create' do
     after do
       FileUtils.rm_rf(file_path)
     end
 
-    context 'a work file attached files' do
+    context 'a work with attached files' do
       it 'creates a bag from the works' do
         work_bag.create
         expect(File.exist?("#{work_bag.bag_path}.zip"))


### PR DESCRIPTION
This changes the wording of the bag notification
to match the wording of #282. It introduces
a method to the `WorkBag` class that is used
to count the number of works in a bag.

Connected to #282