### PR TITLE
Allow markdown in description field for collections. Connected to #257

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -62,7 +62,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("issue_number", :stored_searchable), label: "Number"
     config.add_index_field solr_name("date_created", :stored_sortable, type: :date), itemprop: 'dateCreated', helper_method: :human_readable_date
     config.add_index_field solr_name("abstract", :stored_searchable)
-    config.add_index_field solr_name("description", :stored_searchable), itemprop: 'description', helper_method: :iconify_auto_link
+    config.add_index_field solr_name("description", :stored_searchable), itemprop: 'description', helper_method: :render_with_markdown
     config.add_index_field solr_name("keyword", :stored_searchable), itemprop: 'keywords', link_to_search: solr_name("keyword", :facetable)
     config.add_index_field solr_name("subject", :stored_searchable), itemprop: 'about', link_to_search: solr_name("subject", :facetable)
 

--- a/app/forms/collection_form_markdown.rb
+++ b/app/forms/collection_form_markdown.rb
@@ -1,0 +1,10 @@
+# This is meant to add behavior to
+# Hyrax::Forms::CollectionForm
+# so that we can add markdown to some of the form fields.
+
+module CollectionFormMarkdown
+  def description
+    description_values = super
+    description_values.map { |value| RDF::Markdown::Literal.new(value) }
+  end
+end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,19 @@
+module MarkdownHelper
+  # Temporarily disable rubocop rule to mark the
+  # rendered strings as html_safe.
+  # rubocop:disable Rails/OutputSafety
+  def render_with_markdown(args)
+    renderer = Redcarpet::Render::HTML.new({})
+    markdown = Redcarpet::Markdown.new(renderer, autolink: true)
+
+    # Run user input values through a sanitizer
+    # before marking the strings as html_safe.
+    rendered_values = args[:value].map do |value|
+      sanitized_value = sanitize(value)
+      markdown.render(sanitized_value).html_safe
+    end
+
+    safe_join(rendered_values, ' ')
+  end
+  # rubocop:enable Rails/OutputSafety
+end

--- a/app/views/hyrax/collections/_collection_description.erb
+++ b/app/views/hyrax/collections/_collection_description.erb
@@ -1,0 +1,1 @@
+<%= render_with_markdown(value: presenter.description) %>

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -209,3 +209,9 @@ Date::DATE_FORMATS[:standard] = "%m/%d/%Y"
 Qa::Authorities::Local.register_subauthority('subjects', 'Qa::Authorities::Local::TableBasedAuthority')
 Qa::Authorities::Local.register_subauthority('languages', 'Qa::Authorities::Local::TableBasedAuthority')
 Qa::Authorities::Local.register_subauthority('genres', 'Qa::Authorities::Local::TableBasedAuthority')
+
+# Override collection form class so that we can
+# add markdown to some of the fields in the form.
+Cypripedium::Application.config.after_initialize do
+  Hyrax::Forms::CollectionForm.prepend ::CollectionFormMarkdown
+end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -69,6 +69,8 @@ en:
       defaults:
          related_url: Example - URL for related report. This is a markdown enabled field. This link contains <a href="https://daringfireball.net/projects/markdown/syntax#link">Markdown link instructions</a>. You can also use HTML, and if you enter a URL by itself it will be automatically linked.
          description: Markdown enabled field. This link contains <a href="https://daringfireball.net/projects/markdown/syntax#link">Markdown link instructions</a>. You can also use HTML, and if you enter a URL by itself it will be automatically linked.
+      collection:
+         description: Markdown enabled field. This link contains <a href="https://daringfireball.net/projects/markdown/syntax#link">Markdown link instructions</a>. You can also use HTML, and if you enter a URL by itself it will be automatically linked.
     labels:
       defaults:
         description: Description

--- a/spec/features/edit_markdown_spec.rb
+++ b/spec/features/edit_markdown_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Edit markdown fields:', js: true do
+  let(:admin_user) { FactoryBot.create(:admin) }
+
+  before do
+    DatabaseCleaner.clean_with(:truncation)
+    ActiveFedora::Cleaner.clean!
+    AdminSet.find_or_create_default_admin_set_id
+    login_as admin_user
+  end
+
+  context 'edit a collection' do
+    let(:collection) do
+      coll = Collection.new(
+        title: ['Collection 1'],
+        collection_type: Hyrax::CollectionType.find_or_create_default_collection_type,
+        description: ['Old Description']
+      )
+      coll.apply_depositor_metadata(admin_user.user_key)
+      coll.save!
+      coll
+    end
+
+    # The new description contains markdown text
+    let(:new_description) { good_markdown + malicious_markdown }
+    let(:good_markdown) { 'An [example of a link](http://example.com/) inside a sentence with *italic text*.' }
+    let(:malicious_markdown) { '<script>console.log("javascript attack");</script>' }
+
+    it 'properly saves and displays the markdown' do
+      # The form to edit this collection
+      visit Hyrax::Engine.routes.url_helpers.edit_dashboard_collection_path(collection.id)
+
+      # When the form loads, we see the old description
+      expect(page).to have_content 'Old Description'
+
+      # Fill in the new description and save
+      fill_in 'Description', with: new_description
+      click_on 'Save changes'
+
+      # Go to the show page for this collection
+      visit Hyrax::Engine.routes.url_helpers.dashboard_collection_path(collection.id)
+
+      # The markdown should be rendered
+      expect(page).to have_link('example of a link', href: 'http://example.com/')
+      expect(page).to have_selector('em', text: 'italic text')
+
+      # The potentially malicious javascript should not be run, but should be displayed as text instead
+      expect(page).to have_content('console.log(')
+
+      # Go to the search results page
+      visit search_catalog_path
+
+      # The markdown should be rendered
+      expect(page).to have_link('example of a link', href: 'http://example.com/')
+      expect(page).to have_selector('em', text: 'italic text')
+
+      # The javascript should be displayed as text
+      expect(page).to have_content('console.log(')
+    end
+  end
+end


### PR DESCRIPTION
* For the description on the search results page, I added a helper
method to insert the markdown rendering.

* I overrode a hyrax view to use that same helper method on the show
page for a collection.

* I added a feature spec to make sure the markdown gets rendered without
allowing unsanitized html.

* I added the module CollectionFormMarkdown to allow markdown in the
description field on the form for editing a collection.