### PR TITLE
Fixed a problem where some types of markdown (such as blockquote) weren't being rendered properly.

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,19 +1,15 @@
 module MarkdownHelper
-  # Temporarily disable rubocop rule to mark the
-  # rendered strings as html_safe.
-  # rubocop:disable Rails/OutputSafety
   def render_with_markdown(args)
-    renderer = Redcarpet::Render::HTML.new({})
+    # Use escape_html to sanitize the user inputs so we can later mark it as html_safe.
+    renderer = Redcarpet::Render::HTML.new(escape_html: true)
     markdown = Redcarpet::Markdown.new(renderer, autolink: true)
 
-    # Run user input values through a sanitizer
-    # before marking the strings as html_safe.
     rendered_values = args[:value].map do |value|
-      sanitized_value = sanitize(value)
-      markdown.render(sanitized_value).html_safe
+      # rubocop:disable Rails/OutputSafety
+      markdown.render(value).html_safe
+      # rubocop:enable Rails/OutputSafety
     end
 
     safe_join(rendered_values, ' ')
   end
-  # rubocop:enable Rails/OutputSafety
 end

--- a/app/renderers/hyrax/renderers/description_renderer.rb
+++ b/app/renderers/hyrax/renderers/description_renderer.rb
@@ -6,7 +6,7 @@ module Hyrax
       private
 
         def attribute_value_to_html(value)
-          renderer = Redcarpet::Render::HTML.new({})
+          renderer = Redcarpet::Render::HTML.new(escape_html: true)
           markdown = Redcarpet::Markdown.new(renderer, autolink: true)
           markdown.render(value)
         end

--- a/app/renderers/hyrax/renderers/related_url_renderer.rb
+++ b/app/renderers/hyrax/renderers/related_url_renderer.rb
@@ -6,7 +6,7 @@ module Hyrax
       private
 
         def attribute_value_to_html(value)
-          renderer = Redcarpet::Render::HTML.new({})
+          renderer = Redcarpet::Render::HTML.new(escape_html: true)
           markdown = Redcarpet::Markdown.new(renderer, autolink: true)
           markdown.render(value)
         end

--- a/spec/features/edit_markdown_spec.rb
+++ b/spec/features/edit_markdown_spec.rb
@@ -25,8 +25,9 @@ RSpec.feature 'Edit markdown fields:', js: true do
     end
 
     # The new description contains markdown text
-    let(:new_description) { good_markdown + malicious_markdown }
+    let(:new_description) { [good_markdown, malicious_markdown, good_markdown_2].join("\n\n") }
     let(:good_markdown) { 'An [example of a link](http://example.com/) inside a sentence with *italic text*.' }
+    let(:good_markdown_2) { '>This is a blockquote' }
     let(:malicious_markdown) { '<script>console.log("javascript attack");</script>' }
 
     it 'properly saves and displays the markdown' do
@@ -46,6 +47,10 @@ RSpec.feature 'Edit markdown fields:', js: true do
       # The markdown should be rendered
       expect(page).to have_link('example of a link', href: 'http://example.com/')
       expect(page).to have_selector('em', text: 'italic text')
+
+      within('blockquote') do
+        expect(page).to have_content 'This is a blockquote'
+      end
 
       # The potentially malicious javascript should not be run, but should be displayed as text instead
       expect(page).to have_content('console.log(')


### PR DESCRIPTION
Connected to #257

* Instead of using Rails sanitize method, use redcarpet's escape_html

* Added html escape to the description and related_url fields for Work
records.