### PR TITLE
Always be able to mint ids

### DIFF
--- a/config/initializers/noid_rails.rb
+++ b/config/initializers/noid_rails.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This is a fix for a bug in Hyrax where under certain circumstances the minter
+# stops issuing new IDs, preventing new objects from being created.
+# See https://github.com/samvera/hyrax/issues/3128 for more details.
+::Noid::Rails.config.identifier_in_use = lambda do |id|
+  ActiveFedora::Base.exists?(id) || ActiveFedora::Base.gone?(id)
+end


### PR DESCRIPTION
This is a fix for a bug in Hyrax where under certain circumstances the
minter stops issuing new IDs, preventing new objects from being created.
See samvera/hyrax#3128 for more details.

Connected to #303 