### PR TITLE
Update Gemfile.lock for Bundler 2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,13 +71,13 @@ GEM
       io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.4.0)
-    autoprefixer-rails (9.4.7)
+    autoprefixer-rails (9.4.8)
       execjs
     awesome_nested_set (3.1.4)
       activerecord (>= 4.0.0, < 5.3)
     aws-eventstream (1.0.1)
-    aws-partitions (1.139.0)
-    aws-sdk-core (3.46.1)
+    aws-partitions (1.140.0)
+    aws-sdk-core (3.46.2)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
@@ -123,9 +123,9 @@ GEM
       bootstrap-sass (~> 3.0)
       openseadragon (>= 0.2.0)
       rails
-    bootstrap-sass (3.4.1)
+    bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
-      sassc (>= 2.0.0)
+      sass (>= 3.3.4)
     bootstrap_form (4.1.0)
       rails (>= 5.0)
     breadcrumbs_on_rails (3.0.1)
@@ -215,10 +215,10 @@ GEM
     diff-lcs (1.3)
     docile (1.3.1)
     docopt (0.5.0)
-    dotenv (2.6.0)
-    dotenv-rails (2.6.0)
-      dotenv (= 2.6.0)
-      railties (>= 3.2, < 6.0)
+    dotenv (2.7.0)
+    dotenv-rails (2.7.0)
+      dotenv (= 2.7.0)
+      railties (>= 3.2, < 6.1)
     dropbox_api (0.1.16)
       faraday (>= 0.8, <= 0.15.4)
       oauth2 (~> 1.1)
@@ -284,7 +284,7 @@ GEM
       faraday
     fcrepo_wrapper (0.9.0)
       ruby-progressbar
-    ffi (1.9.25)
+    ffi (1.10.0)
     flipflop (2.4.0)
       activesupport (>= 4.0)
     flot-rails (0.0.7)
@@ -335,7 +335,7 @@ GEM
     hydra-core (10.6.1)
       hydra-access-controls (= 10.6.1)
       railties (>= 4.0.0, < 6)
-    hydra-derivatives (3.4.1)
+    hydra-derivatives (3.4.2)
       active-fedora (>= 11.3.1, < 13)
       active_encode (~> 0.1)
       activesupport (>= 4.0, < 6)
@@ -440,7 +440,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
-    json (2.1.0)
+    json (2.2.0)
     json-ld (3.0.2)
       multi_json (~> 1.12)
       rdf (>= 2.2.8, < 4.0)
@@ -752,9 +752,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.0.0)
-      ffi (~> 1.9.6)
-      rake
     select2-rails (3.5.10)
       thor (~> 0.14)
     selenium-webdriver (3.141.0)
@@ -939,4 +936,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.1
+   2.0.1


### PR DESCRIPTION
We are using Ruby 2.5.3, which will install
bundler v2+ by default. This updates the
Gemfile.lock to expect bundler v2+.