### PR TITLE
Do not save searches for anyone

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -16,8 +16,8 @@ class CatalogController < ApplicationController
   end
 
   configure_blacklight do |config|
-    # Do not store searches for crawler bots
-    config.crawler_detector = ->(req) { req.env['HTTP_USER_AGENT'] =~ /bot/ }
+    # Do not store searches for anyone since Hyrax can't display them anyway
+    config.crawler_detector = ->(req) { true }
 
     config.view.gallery.partials = [:index_header, :index]
     config.view.masonry.partials = [:index]

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,11 +22,6 @@
 
 # Learn more: http://github.com/javan/whenever
 
-# Delete blacklight saved searches
-every :day, at: '11:55pm' do
-  rake 'blacklight:delete_old_searches[1]'
-end
-
 # Remove files in /tmp owned by the deploy user that are older than 7 days
 every :day, at: '1:00am' do
   command '/usr/bin/find /tmp -type f -mtime +7 -user deploy -execdir /bin/rm – {} \\;'

--- a/spec/features/search_crawler_spec.rb
+++ b/spec/features/search_crawler_spec.rb
@@ -4,10 +4,10 @@ include Warden::Test::Helpers
 
 RSpec.describe "Search History Page" do
   describe "crawler search" do
-    it "remembers human searches" do
+    it "doesn't remember human searches" do
       visit root_path
       fill_in "q", with: 'chicken'
-      expect { click_button 'Go' }.to change { Search.count }.by(1)
+      expect { click_button 'Go' }.not_to change { Search.count }
     end
 
     it "doesn't remember bot searches" do


### PR DESCRIPTION
Since Hyrax has no ability to display saved searches, do not save them.
This also eliminates the need to clean them up afterwards, so remove the
old searches cleanup job.

Connected to #333 