### PR TITLE
Upgrade and standardize integration testing setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'redcarpet'
 gem 'redis', '~> 3.0'
 gem 'redis-activesupport'
 gem 'rsolr', '>= 1.0'
-gem 'rubyzip', require: 'zip'
+gem 'rubyzip', '~> 1.0', require: 'zip'
 gem 'sass-rails', '~> 5.0'
 gem 'sassc-rails', '>= 2.1.0'
 gem 'sidekiq'
@@ -70,6 +70,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'selenium-webdriver'
   gem 'solr_wrapper', '>= 0.3'
+  gem 'webdrivers'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -741,7 +741,7 @@ GEM
       oauth2
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
-    rubyzip (2.3.0)
+    rubyzip (1.3.0)
     samvera-nesting_indexer (2.0.0)
       dry-equalizer
     sass (3.7.4)
@@ -870,6 +870,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.4.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -929,7 +933,7 @@ DEPENDENCIES
   redis-activesupport
   rsolr (>= 1.0)
   rspec-rails
-  rubyzip
+  rubyzip (~> 1.0)
   sass-rails (~> 5.0)
   sassc-rails (>= 2.1.0)
   selenium-webdriver
@@ -943,6 +947,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webdrivers
   whenever
   xray-rails
   yard

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+Webdrivers.cache_time = 3
+
+# Setup chrome headless driver
+Capybara.server = :puma, { Silent: true }
+
+Capybara.register_driver :chrome_headless do |app|
+  client = Selenium::WebDriver::Remote::Http::Default.new
+  client.read_timeout = 120
+
+  options = ::Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('--headless')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
+  options.add_argument('--window-size=1400,1400')
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options, http_client: client)
+end
+
+Capybara.javascript_driver = :chrome_headless
+
+# Setup rspec
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by :chrome_headless
+  end
+end

--- a/spec/system/bag_error_notification_spec.rb
+++ b/spec/system/bag_error_notification_spec.rb
@@ -9,7 +9,7 @@ include Warden::Test::Helpers
 # directory exists and there are permissions on the directory
 # this spec creates a situation where the bag directory can't be
 # created.
-RSpec.feature 'Recieve an error notfication when creating a bag', js: true do
+RSpec.describe 'Recieve an error notfication when creating a bag', type: :system, js: true do
   describe 'creating a notification when running a bag job' do
     let(:work_ids) { [1, 2] }
     let(:user) { FactoryBot.create(:admin) }

--- a/spec/system/bag_export_spec.rb
+++ b/spec/system/bag_export_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Bagit export:', js: true do
+RSpec.describe 'Bagit export:', type: :system, js: true do
   let(:admin_user) { FactoryBot.create(:admin) }
 
   before do

--- a/spec/system/bag_notification_spec.rb
+++ b/spec/system/bag_notification_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Recieve a notfication when creating a bag', js: true do
+RSpec.describe 'Recieve a notfication when creating a bag', type: :system, js: true do
   describe 'creating a notification when running a bag job' do
     let(:work_ids) { [publication.id, publication2.id] }
     let(:file_path) { Rails.application.config.bag_path }

--- a/spec/system/create_conference_proceeding_spec.rb
+++ b/spec/system/create_conference_proceeding_spec.rb
@@ -5,7 +5,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Create a ConferenceProceeding', js: true do
+RSpec.describe 'Create a ConferenceProceeding', type: :system, js: true do
   context 'a logged in user' do
     let(:user_attributes) do
       { email: 'test@example.com' }

--- a/spec/system/create_dataset_spec.rb
+++ b/spec/system/create_dataset_spec.rb
@@ -5,7 +5,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Create a Dataset', js: true do
+RSpec.describe 'Create a Dataset', type: :system, js: true do
   context 'a logged in user' do
     let(:user_attributes) do
       { email: 'test@example.com' }

--- a/spec/system/create_publication_spec.rb
+++ b/spec/system/create_publication_spec.rb
@@ -6,7 +6,7 @@ require 'rails_helper'
 
 include Warden::Test::Helpers
 
-RSpec.feature 'Create a Publication', js: true do
+RSpec.describe 'Create a Publication', type: :system, js: true do
   context 'a logged in admin user' do
     let(:user) { FactoryBot.create(:admin) }
     before do

--- a/spec/system/edit_markdown_spec.rb
+++ b/spec/system/edit_markdown_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Edit markdown fields:', js: true do
+RSpec.describe 'Edit markdown fields:', type: :system, js: true do
   let(:admin_user) { FactoryBot.create(:admin) }
 
   before do

--- a/spec/system/search_crawler_spec.rb
+++ b/spec/system/search_crawler_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.describe "Search History Page" do
+RSpec.describe "Search History Page", type: :system do
   describe "crawler search" do
     it "doesn't remember human searches" do
       visit root_path


### PR DESCRIPTION
* Use the DCE standard capybara setup -- standardized setup will make maintenance easier
* Change feature specs to system specs; that's the new rails standard and what we're using elsewhere