### PR TITLE
Insert microdata for creator field

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -208,6 +208,10 @@ end
 
 Date::DATE_FORMATS[:standard] = "%m/%d/%Y"
 
+# Cypripedium needs its own local schema.org config to handle microdata settings
+# for fields that are not configured in base Hyrax, e.g., "alpha_creator"
+Hyrax::Microdata.load_paths << Rails.root.join('config', 'schema_org.yml')
+
 Qa::Authorities::Local.register_subauthority('subjects', 'Qa::Authorities::Local::TableBasedAuthority')
 Qa::Authorities::Local.register_subauthority('languages', 'Qa::Authorities::Local::TableBasedAuthority')
 Qa::Authorities::Local.register_subauthority('genres', 'Qa::Authorities::Local::TableBasedAuthority')

--- a/config/schema_org.yml
+++ b/config/schema_org.yml
@@ -1,0 +1,5 @@
+schema_org:
+  alpha_creator:
+    property: creator
+    type: "http://schema.org/Person"
+    value: name

--- a/spec/factories/dataset.rb
+++ b/spec/factories/dataset.rb
@@ -3,5 +3,12 @@
 FactoryBot.define do
   factory :dataset do
     title { ['Testing'] }
+    factory :populated_dataset do
+      title { ["The 1929 Stock Market: Irving Fisher Was Right: Additional Files"] }
+      creator { ["McGrattan, Ellen R.", "Prescott, Edward C."] }
+      series { ["Staff Report (Federal Reserve Bank of Minneapolis. Research Department)"] }
+      resource_type { ["Dataset"] }
+      visibility { "open" }
+    end
   end
 end

--- a/spec/system/google_structured_data_spec.rb
+++ b/spec/system/google_structured_data_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Use structured data that Google can parse', type: :system, clean: true, js: true do
+  let(:work) { FactoryBot.create(:populated_dataset) }
+
+  context "creator names"
+  it "has expected Google data exposed" do
+    visit "/concern/publications/#{work.id}"
+
+    creators = page.all(:css, 'li.attribute.attribute-alpha_creator')
+    expect(creators.first.find(:css, "[itemprop]").text).to eq "McGrattan, Ellen R."
+    expect(creators.last.find(:css, "[itemprop]").text).to eq "Prescott, Edward C."
+  end
+end


### PR DESCRIPTION
Hyrax by default is configured to display microdata for the
"creator" field. However, cypripedium is using "alpha_creator"
instead of simply "creator", so we need a locally customized
schema.org configuration to match.

Connected to https://github.com/MPLSFedResearch/cypripedium/issues/367