### PR TITLE
Sort by issue number only if no user query

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -263,6 +263,10 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     # label is key, solr field is value
+    # First value in this list is the default sort order. Note that we are changing
+    # the default sort oder in app/models/search_builder.rb so that the contents
+    # of a collection will sort by issue number if there is no query string present.
+    config.add_sort_field "score desc, #{modified_field} desc", label: "relevance"
     config.add_sort_field "issue_number_ssi desc", label: "issue number \u25BC"
     config.add_sort_field "issue_number_ssi asc", label: "issue number \u25B2"
     config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
@@ -271,7 +275,6 @@ class CatalogController < ApplicationController
     config.add_sort_field "title_ssi desc, score desc", label: "title \u25BC"
     config.add_sort_field "date_created_ssi desc", label: "date published \u25BC"
     config.add_sort_field "date_created_ssi asc", label: "date published \u25B2"
-    config.add_sort_field "score desc, #{modified_field} desc", label: "relevance"
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -5,6 +5,18 @@ class SearchBuilder < Blacklight::SearchBuilder
   include Hydra::AccessControlsEnforcement
   include Hyrax::SearchFilters
 
+  self.default_processor_chain += [:sort_by_issue_number_when_no_query]
+
+  ##
+  # Within a collection show page, we want items to be ordered by issue number.
+  # So, if there is no query (solr_parameters["q"]), set the sort to issue number descending.
+  # However, if there IS a query then don't change the sort order, let it stay
+  # sorting by relevance.
+  def sort_by_issue_number_when_no_query(solr_parameters)
+    issue_number_sort = "issue_number_ssi desc, system_modified_dtsi desc"
+    solr_parameters["sort"] = issue_number_sort if solr_parameters["q"].nil?
+  end
+
   ##
   # @example Adding a new step to the processor chain
   #   self.default_processor_chain += [:add_custom_data_to_query]


### PR DESCRIPTION
If a user is performing a search, we want
to use the default sort order: relevancy.
However, if there is no query present,
then relevancy doesn't mean anything.
In that case, sort by issue number so that
collections will show most recent issues
at the top.

Connected to https://github.com/MPLSFedResearch/cypripedium/issues/368