### PR TITLE
Fix sorting on collection show page

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -9,12 +9,14 @@ class SearchBuilder < Blacklight::SearchBuilder
 
   ##
   # Within a collection show page, we want items to be ordered by issue number.
-  # So, if there is no query (solr_parameters["q"]), set the sort to issue number descending.
-  # However, if there IS a query then don't change the sort order, let it stay
-  # sorting by relevance.
+  # So, if there is no query (@blacklight_params[:q]), set the sort to issue number
+  # descending.
+  # However, if there IS a query or an explicit sort parameter then don't change
+  # the sort order.
   def sort_by_issue_number_when_no_query(solr_parameters)
+    return unless @blacklight_params[:controller] == "hyrax/collections"
     issue_number_sort = "issue_number_ssi desc, system_modified_dtsi desc"
-    solr_parameters["sort"] = issue_number_sort if solr_parameters["q"].nil?
+    solr_parameters["sort"] = issue_number_sort if @blacklight_params[:q].nil? && @blacklight_params[:sort].nil?
   end
 
   ##

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe SearchBuilder do
+  let(:search_builder) { described_class.new(context) }
+  let(:blacklight_config) { CatalogController.blacklight_config.deep_copy }
+  let(:context) { CatalogController.new }
+  before { allow(context).to receive(:blacklight_config).and_return(blacklight_config) }
+
+  describe "default processor chain" do
+    let(:customized_processor_chain) do
+      [
+        :default_solr_parameters,
+        :add_query_to_solr,
+        :add_facet_fq_to_solr,
+        :add_facetting_to_solr,
+        :add_solr_fields_to_query,
+        :add_paging_to_solr,
+        :add_sorting_to_solr,
+        :add_group_config_to_solr,
+        :add_facet_paging_to_solr,
+        :add_access_controls_to_solr_params,
+        :filter_models,
+        :only_active_works,
+        :sort_by_issue_number_when_no_query
+      ]
+    end
+    it "has the expected default processor chain" do
+      expect(search_builder.processor_chain).to eq customized_processor_chain
+    end
+  end
+end

--- a/spec/system/bag_export_spec.rb
+++ b/spec/system/bag_export_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'Bagit export:', type: :system, js: true do
     end
 
     before do
+      I18n.locale = 'en'
       ActiveJob::Base.queue_adapter = :test
       [publication, data_set] # Create the records
     end

--- a/spec/system/collection_item_ordering_spec.rb
+++ b/spec/system/collection_item_ordering_spec.rb
@@ -14,9 +14,18 @@ RSpec.describe 'When displaying a collection, sort by issue number', type: :syst
     coll.save!
     coll
   end
+  let(:titles) do
+    [
+      'Antsy Aardvark',
+      'Busy Beaver',
+      'Cunning Cougar',
+      'Devious Dog',
+      'Elegant Elephant'
+    ]
+  end
   let(:collection_members) do
     [5, 4, 3, 2, 1].each do |i|
-      p = FactoryBot.create(:publication, issue_number: [i.to_s], depositor: admin_user.user_key)
+      p = FactoryBot.create(:publication, issue_number: [i.to_s], title: [titles[i - 1]], depositor: admin_user.user_key)
       p.member_of_collections << collection
       p.save
     end
@@ -33,6 +42,14 @@ RSpec.describe 'When displaying a collection, sort by issue number', type: :syst
       visit Hyrax::Engine.routes.url_helpers.collection_path(collection.id)
       expect(page.find(:xpath, '/HTML/BODY[1]/DIV[3]/DIV[1]/DIV[7]/TABLE[1]/TBODY[1]/TR[1]/TD[3]').text). to eq "5"
       expect(page.find(:xpath, '/HTML/BODY[1]/DIV[3]/DIV[1]/DIV[7]/TABLE[1]/TBODY[1]/TR[5]/TD[3]').text). to eq "1"
+    end
+
+    it 'can reorder by title' do
+      visit Hyrax::Engine.routes.url_helpers.collection_path(collection.id)
+      page.find(:css, '#sort').find(:xpath, 'option[6]').select_option
+      page.find_all(:xpath, '//button')[2].click
+      expect(page.find(:xpath, '/HTML/BODY[1]/DIV[3]/DIV[1]/DIV[7]/TABLE[1]/TBODY[1]/TR[1]/TD[3]').text). to eq "1"
+      expect(page.find(:xpath, '/HTML/BODY[1]/DIV[3]/DIV[1]/DIV[7]/TABLE[1]/TBODY[1]/TR[5]/TD[3]').text). to eq "5"
     end
   end
 end


### PR DESCRIPTION
When we added a default sort by issue number on the collection show page we inadvertently broke the ability to sort by other fields. This PR fixes that bug.

Connected to https://github.com/MPLSFedResearch/cypripedium/issues/403