### PR TITLE
Render a static page for 404 errors

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,6 +3,6 @@
 class PagesController < ApplicationController
   def error_404
     flash[:alert] = 'The page you are looking for does not exist.'
-    render status: 404
+    render file: Rails.root.join('public', '404.html'), status: 404
   end
 end

--- a/spec/system/404_spec.rb
+++ b/spec/system/404_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Getting a 404 for RecordNotFound', type: :system do
     it 'has a 404 page' do
       visit('/concern/works/s7526c41m?locale=pt-BR')
       expect(page).to have_content('does not exist')
+      expect(page).to have_content('You may have mistyped the address or the page may have moved.')
     end
   end
 
@@ -16,6 +17,7 @@ RSpec.describe 'Getting a 404 for RecordNotFound', type: :system do
     it 'has a 404 page' do
       visit('/bla/bla/bla')
       expect(page).to have_content('does not exist')
+      expect(page).to have_content('You may have mistyped the address or the page may have moved.')
     end
   end
 end


### PR DESCRIPTION
This should eliminate the error we're getting in honeybadger: Missing template pages/error_404