### PR TITLE
Use spring for rspec to speed up local development cycle time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ group :development, :test do
   gem 'rspec_junit_formatter'
   gem 'selenium-webdriver'
   gem 'solr_wrapper', '>= 0.3'
+  gem 'spring-commands-rspec'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -860,6 +860,8 @@ GEM
       net-http-persistent (~> 3.1)
       rdf (~> 3.1)
     spring (2.1.0)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -988,6 +990,7 @@ DEPENDENCIES
   simple_form (>= 5.0.0)
   solr_wrapper (>= 0.3)
   spring
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   sqlite3 (~> 1.3.6)
   turbolinks (~> 5)

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')


### PR DESCRIPTION
Before this change, files took over 20 seconds to load (even when running only one test).  With this change, when running "bundle exec spring rspec", "Finished in 4 minutes 0 seconds (files took 2.18 seconds to load)"

Co-Authored-By: Max Kadel <max@curationexperts.com>