### PR TITLE
Re-enable system spec

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -108,7 +108,7 @@ Hyrax.config do |config|
   # implied when the save button is pressed? Set to true for active
   # The default is true.
   # TODO: Turn off checkbox - will likely break javascript that enables the Save button in spec/system/create_publication_spec.rb
-  # config.active_deposit_agreement_acceptance = false
+  config.active_deposit_agreement_acceptance = ENV["RAILS_ENV"] == "production" ? false : true
 
   # Should work creation require file upload, or can a work be created first
   # and a file added at a later time?

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -107,7 +107,8 @@ Hyrax.config do |config|
   # Should the acceptance of the licence agreement be active (checkbox), or
   # implied when the save button is pressed? Set to true for active
   # The default is true.
-  config.active_deposit_agreement_acceptance = false
+  # TODO: Turn off checkbox - will likely break javascript that enables the Save button in spec/system/create_publication_spec.rb
+  # config.active_deposit_agreement_acceptance = false
 
   # Should work creation require file upload, or can a work be created first
   # and a file added at a later time?

--- a/spec/system/create_publication_spec.rb
+++ b/spec/system/create_publication_spec.rb
@@ -22,9 +22,8 @@ RSpec.describe 'Create a Publication', type: :system, js: true do
         fill_in 'Creator', with: 'Alvarez, Fernando, 1964-'
         find('body').click
         click_link 'Files'
-        within('#addfiles') do
-          attach_file("files[]", "spec/fixtures/files/pdf-sample.pdf", visible: false)
-        end
+        execute_script("$('.fileinput-button input:first').css({'opacity':'1', 'display':'block', 'position':'relative'})")
+        attach_file('files[]', File.absolute_path(file_fixture('pdf-sample.pdf')))
         sleep(1)
         choose('publication_visibility_open')
         # puts "Required metadata: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').requiredFields.areComplete})}"
@@ -36,7 +35,7 @@ RSpec.describe 'Create a Publication', type: :system, js: true do
         # so no work show page appears. Save the form
         find('#agreement').click
         find('#with_files_submit').click
-        sleep(1)
+        sleep(5)
         expect(page).to have_selector 'h1', text: 'Title for controller vocab test'
       end
     end

--- a/spec/system/create_publication_spec.rb
+++ b/spec/system/create_publication_spec.rb
@@ -13,32 +13,6 @@ RSpec.describe 'Create a Publication', type: :system, js: true do
       login_as user
       AdminSet.find_or_create_default_admin_set_id
     end
-    describe 'limited entries' do
-      let(:creator) { FactoryBot.create(:creator) }
-      scenario 'fill in and submit limited form' do
-        visit '/concern/publications/new'
-        fill_in 'Title', with: 'Title for controller vocab test'
-        find('#publication_creator').click
-        fill_in 'Creator', with: 'Alvarez, Fernando, 1964-'
-        find('body').click
-        click_link 'Files'
-        execute_script("$('.fileinput-button input:first').css({'opacity':'1', 'display':'block', 'position':'relative'})")
-        attach_file('files[]', File.absolute_path(file_fixture('pdf-sample.pdf')))
-        sleep(1)
-        choose('publication_visibility_open')
-        # puts "Required metadata: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').requiredFields.areComplete})}"
-        # puts "Required files: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').uploads.hasFiles})}"
-        # puts "Agreement : #{page.evaluate_script(%{$('#form-progress').data('save_work_control').depositAgreement.isAccepted})}"
-        # save_button = %{$('#form-progress').data('save_work_control').isSaveButtonEnabled}
-        # puts "saveButtonEnabled: #{page.evaluate_script(save_button)}"
-        # TODO: Capybara / Selenium not re-enabling submit button when agreement initializer set to false
-        # so no work show page appears. Save the form
-        find('#agreement').click
-        find('#with_files_submit').click
-        sleep(5)
-        expect(page).to have_selector 'h1', text: 'Title for controller vocab test'
-      end
-    end
 
     scenario 'fill in and submit the form' do
       visit '/concern/publications/new'

--- a/spec/system/create_publication_spec.rb
+++ b/spec/system/create_publication_spec.rb
@@ -13,6 +13,35 @@ RSpec.describe 'Create a Publication', type: :system, js: true do
       login_as user
       AdminSet.find_or_create_default_admin_set_id
     end
+    describe 'limited entries' do
+      let(:creator) { FactoryBot.create(:creator) }
+      scenario 'fill in and submit limited form' do
+        visit '/concern/publications/new'
+        fill_in 'Title', with: 'Title for controller vocab test'
+        find('#publication_creator').click
+        fill_in 'Creator', with: 'Alvarez, Fernando, 1964-'
+        find('body').click
+        click_link 'Files'
+        within('#addfiles') do
+          attach_file("files[]", "spec/fixtures/files/pdf-sample.pdf", visible: false)
+        end
+        sleep(1)
+        find('#agreement').click
+        choose('publication_visibility_open')
+        puts "Required metadata: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').requiredFields.areComplete})}"
+        puts "Required files: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').uploads.hasFiles})}"
+        puts "Agreement : #{page.evaluate_script(%{$('#form-progress').data('save_work_control').depositAgreement.isAccepted})}"
+
+        save_button = %{$('#form-progress').data('save_work_control').isSaveButtonEnabled}
+        puts "saveButtonEnabled: #{page.evaluate_script(save_button)}"
+        expect(find('#with_files_submit').disabled?).to eq false
+        # TODO: Capybara / Selenium not re-enabling submit button when agreement initializer set to false
+        # so no work show page appears. Save the form
+        find('#with_files_submit').click
+        expect(page).to have_selector 'h1', text: 'Title'
+      end
+    end
+
 
     scenario 'fill in and submit the form' do
       visit '/concern/publications/new'
@@ -57,17 +86,13 @@ RSpec.describe 'Create a Publication', type: :system, js: true do
       fill_in 'Temporal', with: 'Temporal'
       fill_in 'Table of Contents', with: 'Table of Contents'
 
-      find('body').click
+
       click_link 'Files'
 
       execute_script("$('.fileinput-button input:first').css({'opacity':'1', 'display':'block', 'position':'relative'})")
       attach_file('files[]', File.absolute_path(file_fixture('pdf-sample.pdf')))
       sleep(1)
-      # With selenium and the chrome driver, focus remains on the
-      # select box. Click outside the box so the next line can't find
-      # its element
 
-      find('body').click
       choose('publication_visibility_open')
       expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
       # These lines are for debugging, should this test fail
@@ -75,40 +100,42 @@ RSpec.describe 'Create a Publication', type: :system, js: true do
       # puts "Required files: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').uploads.hasFiles})}"
       # puts "Agreement : #{page.evaluate_script(%{$('#form-progress').data('save_work_control').depositAgreement.isAccepted})}"
 
-      # TO DO: Capybara not kicking off method to submit
+      # TODO: Capybara / Selenium not re-enabling submit button when agreement initializer set to false
       # so no work show page appears. Save the form
-      # find('#with_files_submit').click
+      find('#agreement').click
+      find('#with_files_submit').click
+      sleep(5)
 
       # Now we are on the show page for the new record
-      # expect(page).to have_selector 'h1', text: 'Title'
-      # expect(page).to have_content('Staff Reports (Federal Reserve Bank of Minneapolis. Research Division.)')
-      # expect(page).to have_content('111')
-      # expect(page).to have_content('2019-05-01')
-      # expect(page).to have_content('Description')
-      # expect(page).to have_content('Abstract')
-      # expect(page).to have_content('A10 - General Economics: General')
-      # expect(page).to have_content('Keyword')
-      # expect(page).to have_content('Table of Contents')
-      # expect(page).to have_link('http://curationexperts.com')
-      # expect(page).to have_content('Alternative Title')
-      # expect(page).to have_content('Date Available')
-      # expect(page).to have_content('Contributor')
-      # expect(page).to have_content('Language')
-      # expect(page).to have_content('Federal Reserve Bank of Minneapolis. Research Division.')
-      # expect(page).to have_content('Federal Reserve Bank of Minneapolis. Research Division.')
-      # expect(page).to have_content('Article')
-      # expect(page).to have_content('Source')
-      # expect(page).to have_content('Temporal')
-      # expect(page).to have_content('Extent')
-      # expect(page).to have_content('Bibliographic Citation')
-      # expect(page).to have_content('DOI')
-      # expect(page).not_to have_content('Relation: Has Part')
-      # expect(page).not_to have_content('Relation: Is Version Of')
-      # expect(page).not_to have_content('Relation: Has Version')
-      # expect(page).not_to have_content('Relation: Is Replaced By')
-      # expect(page).not_to have_content('Relation: Requires')
-      # expect(page).to have_content('Spatial')
-      # expect(page).to have_content('Title')
+      expect(page).to have_selector 'h1', text: 'Title'
+      expect(page).to have_content('Staff Reports (Federal Reserve Bank of Minneapolis. Research Division.)')
+      expect(page).to have_content('111')
+      expect(page).to have_content('2019-05-01')
+      expect(page).to have_content('Description')
+      expect(page).to have_content('Abstract')
+      expect(page).to have_content('A10 - General Economics: General')
+      expect(page).to have_content('Keyword')
+      expect(page).to have_content('Table of Contents')
+      expect(page).to have_link('http://curationexperts.com')
+      expect(page).to have_content('Alternative Title')
+      expect(page).to have_content('Date Available')
+      expect(page).to have_content('Contributor')
+      expect(page).to have_content('Language')
+      expect(page).to have_content('Federal Reserve Bank of Minneapolis. Research Division.')
+      expect(page).to have_content('Federal Reserve Bank of Minneapolis. Research Division.')
+      expect(page).to have_content('Article')
+      expect(page).to have_content('Source')
+      expect(page).to have_content('Temporal')
+      expect(page).to have_content('Extent')
+      expect(page).to have_content('Bibliographic Citation')
+      expect(page).to have_content('DOI')
+      expect(page).not_to have_content('Relation: Has Part')
+      expect(page).not_to have_content('Relation: Is Version Of')
+      expect(page).not_to have_content('Relation: Has Version')
+      expect(page).not_to have_content('Relation: Is Replaced By')
+      expect(page).not_to have_content('Relation: Requires')
+      expect(page).to have_content('Spatial')
+      expect(page).to have_content('Title')
     end
   end
 end

--- a/spec/system/create_publication_spec.rb
+++ b/spec/system/create_publication_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe 'Create a Publication', type: :system, js: true do
         # so no work show page appears. Save the form
         find('#agreement').click
         find('#with_files_submit').click
+        sleep(1)
         expect(page).to have_selector 'h1', text: 'Title for controller vocab test'
       end
     end

--- a/spec/system/create_publication_spec.rb
+++ b/spec/system/create_publication_spec.rb
@@ -26,19 +26,17 @@ RSpec.describe 'Create a Publication', type: :system, js: true do
           attach_file("files[]", "spec/fixtures/files/pdf-sample.pdf", visible: false)
         end
         sleep(1)
-        find('#agreement').click
         choose('publication_visibility_open')
-        puts "Required metadata: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').requiredFields.areComplete})}"
-        puts "Required files: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').uploads.hasFiles})}"
-        puts "Agreement : #{page.evaluate_script(%{$('#form-progress').data('save_work_control').depositAgreement.isAccepted})}"
-
-        save_button = %{$('#form-progress').data('save_work_control').isSaveButtonEnabled}
-        puts "saveButtonEnabled: #{page.evaluate_script(save_button)}"
-        expect(find('#with_files_submit').disabled?).to eq false
+        # puts "Required metadata: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').requiredFields.areComplete})}"
+        # puts "Required files: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').uploads.hasFiles})}"
+        # puts "Agreement : #{page.evaluate_script(%{$('#form-progress').data('save_work_control').depositAgreement.isAccepted})}"
+        # save_button = %{$('#form-progress').data('save_work_control').isSaveButtonEnabled}
+        # puts "saveButtonEnabled: #{page.evaluate_script(save_button)}"
         # TODO: Capybara / Selenium not re-enabling submit button when agreement initializer set to false
         # so no work show page appears. Save the form
+        find('#agreement').click
         find('#with_files_submit').click
-        expect(page).to have_selector 'h1', text: 'Title'
+        expect(page).to have_selector 'h1', text: 'Title for controller vocab test'
       end
     end
 

--- a/spec/system/create_publication_spec.rb
+++ b/spec/system/create_publication_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe 'Create a Publication', type: :system, js: true do
       end
     end
 
-
     scenario 'fill in and submit the form' do
       visit '/concern/publications/new'
       expect(page).to have_content "Add New Publication"
@@ -85,7 +84,6 @@ RSpec.describe 'Create a Publication', type: :system, js: true do
       fill_in 'Spatial', with: 'Spatial'
       fill_in 'Temporal', with: 'Temporal'
       fill_in 'Table of Contents', with: 'Table of Contents'
-
 
       click_link 'Files'
 


### PR DESCRIPTION
- Currently in order to pass, need to re-enable accepting deposit agreement explicitly
- Seems to be some kind of bug in the javascript for re-enabling the save button

Co-Authored-By: Rachel Kadel <rachel.kadel@curationexperts.com>