### PR TITLE
Finish allowing nested creator_ids - all but JS

### DIFF
--- a/app/forms/hyrax/cypripedium_form.rb
+++ b/app/forms/hyrax/cypripedium_form.rb
@@ -6,7 +6,7 @@ module Hyrax
     self.required_fields = [:title]
 
     def primary_terms
-      [:title, :series, :issue_number, :creator, :date_created, :keyword, :subject,
+      [:title, :series, :issue_number, :creator, :creator_id, :date_created, :keyword, :subject,
        :abstract, :description, :identifier, :related_url, :corporate_name, :publisher, :resource_type, :license]
     end
 
@@ -27,18 +27,17 @@ module Hyrax
     # This describes the parameters we are expecting to receive from the client
     # @return [Array] a list of parameters used by sanitize_params
     def self.build_permitted_params
-      super
-      # super + [
-      #   :on_behalf_of,
-      #   :version,
-      #   :add_works_to_collection,
-      #   {
-      #     creator_id_attributes: [:id, :_destroy],
-      #     based_near_attributes: [:id, :_destroy],
-      #     member_of_collections_attributes: [:id, :_destroy],
-      #     work_members_attributes: [:id, :_destroy]
-      #   }
-      # ]
+      super + [
+        :on_behalf_of,
+        :version,
+        :add_works_to_collection,
+        {
+          creator_id_attributes: [:id, :_destroy],
+          based_near_attributes: [:id, :_destroy],
+          member_of_collections_attributes: [:id, :_destroy],
+          work_members_attributes: [:id, :_destroy]
+        }
+      ]
     end
   end
 end

--- a/app/models/conference_proceeding.rb
+++ b/app/models/conference_proceeding.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class ConferenceProceeding < CypripediumWork
+  include ::Hyrax::BasicMetadata
+  id_blank = proc { |attributes| attributes[:id].blank? }
+  accepts_nested_attributes_for :creator_id, reject_if: id_blank, allow_destroy: true
 end

--- a/app/models/cypripedium_work.rb
+++ b/app/models/cypripedium_work.rb
@@ -10,5 +10,4 @@ class CypripediumWork < ActiveFedora::Base
 
   validates :title, presence: { message: 'Your work must have a title.' }
   self.indexer = CypripediumIndexer
-  include ::Hyrax::BasicMetadata
 end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class Dataset < CypripediumWork
+  include ::Hyrax::BasicMetadata
+  id_blank = proc { |attributes| attributes[:id].blank? }
+  accepts_nested_attributes_for :creator_id, reject_if: id_blank, allow_destroy: true
 end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class Publication < CypripediumWork
+  include ::Hyrax::BasicMetadata
+  id_blank = proc { |attributes| attributes[:id].blank? }
+  accepts_nested_attributes_for :creator_id, reject_if: id_blank, allow_destroy: true
 end

--- a/app/views/records/edit_fields/_creator_id.html.erb
+++ b/app/views/records/edit_fields/_creator_id.html.erb
@@ -1,0 +1,15 @@
+<%= f.input key,
+        as: :controlled_vocabulary,
+        placeholder: 'Autocomplete field.',
+        input_html: {
+          class: 'form-control',
+          data: { 'autocomplete-url' => "/authorities/search/creator_authority",
+                  'autocomplete' => key,
+                  'field-type' => 'linked_data' }
+        },
+
+        ### Required for the ControlledVocabulary javascript:
+        wrapper_html: { data: { 'autocomplete-url' => "/authorities/search/creator_authority",
+                                'field-name' => key }},
+
+        required: f.object.required?(key) %>


### PR DESCRIPTION
This includes all the changes that are necessary to allow the creator_ids to act as a controlled vocabulary *except* for the Javascript override in Hyrax in app/assets/javascripts/hyrax/autocomplete.es6 byFieldName 

I believe the tests are passing, but attempting to use the creator_id via the UI will raise errors, because without the Javascript change it won't pass the right values to the controller. 