### PR TITLE
Use solr to locate works associated with a creator for reindex

### DIFF
--- a/app/indexers/indexes_metadata.rb
+++ b/app/indexers/indexes_metadata.rb
@@ -6,7 +6,7 @@ module IndexesMetadata
       solr_doc['title_ssi'] = object.title.first
       solr_doc['date_created_ssi'] = object.date_created.first
       solr_doc['creator_tesim'] = creator_alternate_names(object).to_a + creator_names(object).to_a
-      solr_doc['alpha_creator_tesim'] = creator_names(object).sort
+      solr_doc['alpha_creator_tesim'] = creator_names(object).reject(&:blank?).sort
       solr_doc['creator_sim'] = creator_names(object)
       solr_doc['creator_id_ssim'] = creator_numerical_ids(object) if creator_numerical_ids(object)
     end
@@ -14,8 +14,8 @@ module IndexesMetadata
 
   def creator_names(object)
     @creator_names ||= if object.creator_id.present?
-                         creator_numerical_ids(object).map do |creator_id|
-                           Creator.find(creator_id).display_name
+                         creator_numerical_ids(object).flat_map do |creator_id|
+                           Creator.find_by(id: creator_id)&.display_name
                          end
                        else
                          object.creator
@@ -25,7 +25,7 @@ module IndexesMetadata
   def creator_alternate_names(object)
     @creator_alternate_names ||= if object.creator_id.present?
                                    creator_numerical_ids(object).flat_map do |creator_id|
-                                     Creator.find(creator_id).alternate_names
+                                     Creator.find_by(id: creator_id)&.alternate_names
                                    end
                                  else
                                    object.creator.flat_map do |name|

--- a/app/indexers/indexes_metadata.rb
+++ b/app/indexers/indexes_metadata.rb
@@ -6,7 +6,7 @@ module IndexesMetadata
       solr_doc['title_ssi'] = object.title.first
       solr_doc['date_created_ssi'] = object.date_created.first
       solr_doc['creator_tesim'] = creator_alternate_names(object).to_a + creator_names(object).to_a
-      solr_doc['alpha_creator_tesim'] = creator_names(object).reject(&:blank?).sort
+      solr_doc['alpha_creator_tesim'] = creator_names(object).sort
       solr_doc['creator_sim'] = creator_names(object)
       solr_doc['creator_id_ssim'] = creator_numerical_ids(object) if creator_numerical_ids(object)
     end
@@ -16,7 +16,7 @@ module IndexesMetadata
     @creator_names ||= if object.creator_id.present?
                          creator_numerical_ids(object).flat_map do |creator_id|
                            Creator.find_by(id: creator_id)&.display_name
-                         end
+                         end.reject(&:blank?)
                        else
                          object.creator
                        end
@@ -26,11 +26,11 @@ module IndexesMetadata
     @creator_alternate_names ||= if object.creator_id.present?
                                    creator_numerical_ids(object).flat_map do |creator_id|
                                      Creator.find_by(id: creator_id)&.alternate_names
-                                   end
+                                   end.reject(&:blank?)
                                  else
                                    object.creator.flat_map do |name|
                                      Creator.find_by(display_name: name)&.alternate_names
-                                   end
+                                   end.reject(&:blank?)
                                  end
   end
 

--- a/app/indexers/indexes_metadata.rb
+++ b/app/indexers/indexes_metadata.rb
@@ -8,6 +8,7 @@ module IndexesMetadata
       solr_doc['creator_tesim'] = creator_alternate_names(object).to_a + creator_names(object).to_a
       solr_doc['alpha_creator_tesim'] = creator_names(object).sort
       solr_doc['creator_sim'] = creator_names(object)
+      solr_doc['creator_id_ssim'] = creator_numerical_ids(object) if creator_numerical_ids(object)
     end
   end
 
@@ -34,5 +35,13 @@ module IndexesMetadata
                                      Creator.find_by(display_name: name)&.alternate_names
                                    end
                                  end
+  end
+
+  def creator_numerical_ids(object)
+    @creator_numerical_ids ||= if object.creator_id.present?
+                                 object.creator_id.map do |creator_triple|
+                                   URI(creator_triple.id).path.split('/').last
+                                 end
+                               end
   end
 end

--- a/app/indexers/indexes_metadata.rb
+++ b/app/indexers/indexes_metadata.rb
@@ -14,10 +14,8 @@ module IndexesMetadata
 
   def creator_names(object)
     @creator_names ||= if object.creator_id.present?
-                         object.creator_id.map do |creator_triple|
-                           creator_id = URI(creator_triple.id).path.split('/').last
+                         creator_numerical_ids(object).map do |creator_id|
                            Creator.find(creator_id).display_name
-                           # Creator.find_by(display_name: object.creator_id)
                          end
                        else
                          object.creator
@@ -26,8 +24,7 @@ module IndexesMetadata
 
   def creator_alternate_names(object)
     @creator_alternate_names ||= if object.creator_id.present?
-                                   object.creator_id.flat_map do |creator_triple|
-                                     creator_id = URI(creator_triple.id).path.split('/').last
+                                   creator_numerical_ids(object).flat_map do |creator_id|
                                      Creator.find(creator_id).alternate_names
                                    end
                                  else

--- a/app/models/creator.rb
+++ b/app/models/creator.rb
@@ -9,7 +9,7 @@ class Creator < ApplicationRecord
     solr = Blacklight.default_index.connection
     response = solr.get 'select', params: { q: "creator_id_ssim:#{id}" }
     response['response']['docs'].each do |doc|
-      doc['has_model_ssim'].first.constantize.find(doc['id']).update_index
+      CypripediumWork.find(doc['id']).update_index
     end
   end
 

--- a/app/models/creator.rb
+++ b/app/models/creator.rb
@@ -6,14 +6,10 @@ class Creator < ApplicationRecord
   after_save :reindex_associated_works
 
   def reindex_associated_works
-    Publication.where(creator_id_ssim: id.to_s).find_each do |record|
-      record.update_index
-    end
-    Dataset.where(creator_id_ssim: id.to_s).find_each do |record|
-      record.update_index
-    end
-    ConferenceProceeding.where(creator_id_ssim: id.to_s).find_each do |record|
-      record.update_index
+    solr = Blacklight.default_index.connection
+    response = solr.get 'select', params: { q: "creator_id_ssim:#{id}" }
+    response['response']['docs'].each do |doc|
+      doc['has_model_ssim'].first.constantize.find(doc['id']).update_index
     end
   end
 

--- a/spec/indexers/cypripedium_indexer_spec.rb
+++ b/spec/indexers/cypripedium_indexer_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe CypripediumIndexer, clean: true do
       let(:attrs) {
         { title: ['My Title'],
           date_created: ['1970-04'],
-          # creator: ['Kehoe, Patrick J.', 'Backus, David', 'Kehoe, Timothy J.'],
           creator_id: [creator_one.authority_rdf, creator_two.authority_rdf, creator_three.authority_rdf] }
       }
       it 'indexes a sortable title and date created' do
@@ -32,9 +31,9 @@ RSpec.describe CypripediumIndexer, clean: true do
         # Wait! But with Fedora we have to totally write over the whole array anyway, so if we find the ID in
         # the creator_id array we can replace the whole set of creator names
         creator_id_array = solr_doc['creator_id_ssim']
-        expect(creator_id_array).to include creator_one.authority_rdf.id.to_s
-        expect(creator_id_array).to include creator_two.authority_rdf.id.to_s
-        expect(creator_id_array).to include creator_three.authority_rdf.id.to_s
+        expect(creator_id_array).to include creator_one.id.to_s
+        expect(creator_id_array).to include creator_two.id.to_s
+        expect(creator_id_array).to include creator_three.id.to_s
         creator_array = solr_doc['creator_tesim']
         expect(creator_array).to include 'Kehoe, Patrick J.'
         expect(creator_array).to include 'Backus, David'
@@ -52,9 +51,9 @@ RSpec.describe CypripediumIndexer, clean: true do
         expect(data_doc['title_ssi']).to eq 'My Title'
         expect(data_doc['date_created_ssi']).to eq '1970-04'
         creator_id_array = data_doc['creator_id_ssim']
-        expect(creator_id_array).to include creator_one.authority_rdf.id.to_s
-        expect(creator_id_array).to include creator_two.authority_rdf.id.to_s
-        expect(creator_id_array).to include creator_three.authority_rdf.id.to_s
+        expect(creator_id_array).to include creator_one.id.to_s
+        expect(creator_id_array).to include creator_two.id.to_s
+        expect(creator_id_array).to include creator_three.id.to_s
         creator_array = data_doc['creator_tesim']
         expect(creator_array).to include 'Kehoe, Patrick J.'
         expect(creator_array).to include 'Backus, David'
@@ -66,9 +65,9 @@ RSpec.describe CypripediumIndexer, clean: true do
         expect(conf_doc['title_ssi']).to eq 'My Title'
         expect(conf_doc['date_created_ssi']).to eq '1970-04'
         creator_id_array = conf_doc['creator_id_ssim']
-        expect(creator_id_array).to include creator_one.authority_rdf.id.to_s
-        expect(creator_id_array).to include creator_two.authority_rdf.id.to_s
-        expect(creator_id_array).to include creator_three.authority_rdf.id.to_s
+        expect(creator_id_array).to include creator_one.id.to_s
+        expect(creator_id_array).to include creator_two.id.to_s
+        expect(creator_id_array).to include creator_three.id.to_s
         creator_array = conf_doc['creator_tesim']
         expect(creator_array).to include 'Kehoe, Patrick J.'
         expect(creator_array).to include 'Backus, David'

--- a/spec/models/creator_spec.rb
+++ b/spec/models/creator_spec.rb
@@ -50,6 +50,25 @@ RSpec.describe Creator, type: :model do
       expect(response['response']['docs'].first['creator_tesim']).not_to include "McGrattan, Ellen R."
     end
   end
+  context 'with an accidentally-deleted creator' do
+    let(:work) {
+      FactoryBot.build(:populated_publication,
+      creator_id: [creator_one.authority_rdf, creator_two.authority_rdf, creator_three.authority_rdf])
+    }
+    let(:solr) { Blacklight.default_index.connection }
+    let(:creator_one) { FactoryBot.create(:creator, display_name: 'Kehoe, Patrick J.') }
+    let(:creator_two) { FactoryBot.create(:creator, display_name: 'Backus, David', alternate_names: ['Backus, Davey', 'Backus-Up, David']) }
+    let(:creator_three) { FactoryBot.create(:creator, display_name: 'Kehoe, Timothy J.') }
+
+    it "fails gracefully" do
+      creator_one
+      creator_two
+      work.save!
+      creator_one.delete
+      creator_two.display_name = 'Else, Somebody'
+      creator_two.save!
+    end
+  end
   it "accepts an active field" do
     creator = described_class.create(display_name: "Allen, Stephen G.", active_creator: false)
     expect(creator.active_creator).to eq false

--- a/spec/models/creator_spec.rb
+++ b/spec/models/creator_spec.rb
@@ -61,12 +61,10 @@ RSpec.describe Creator, type: :model do
     let(:creator_three) { FactoryBot.create(:creator, display_name: 'Kehoe, Timothy J.') }
 
     it "fails gracefully" do
-      creator_one
-      creator_two
       work.save!
       creator_one.delete
       creator_two.display_name = 'Else, Somebody'
-      creator_two.save!
+      expect { creator_two.save! }.not_to raise_error
     end
   end
   it "accepts an active field" do


### PR DESCRIPTION
Previous version of reindex_associated_works was grinding through fedora instead of searching solr, resulting in performance problems.