### PR TITLE
Ignore disabled creators

### DIFF
--- a/app/authorities/qa/authorities/creator_authority.rb
+++ b/app/authorities/qa/authorities/creator_authority.rb
@@ -4,7 +4,7 @@ module Qa::Authorities
     # Corresponds to endpoint authorities/search/creator_authority?q=[q]
     # e.g. authorities/search/creator_authority?q=Car
     def search(q)
-      results = Creator.where('lower(display_name) like ?', "#{q.downcase}%").limit(25)
+      results = Creator.where('active_creator AND lower(display_name) like ?', "#{q.downcase}%").limit(25)
       map_results(results)
     end
 

--- a/spec/models/creator_spec.rb
+++ b/spec/models/creator_spec.rb
@@ -2,6 +2,9 @@
 require 'rails_helper'
 
 RSpec.describe Creator, type: :model do
+  before do
+    I18n.locale = 'en'
+  end
   it "has a ID" do
     creator = described_class.create(display_name: "Allen, Stephen G.")
     expect(creator.id).not_to be nil

--- a/spec/models/creator_spec.rb
+++ b/spec/models/creator_spec.rb
@@ -2,9 +2,6 @@
 require 'rails_helper'
 
 RSpec.describe Creator, type: :model do
-  before do
-    I18n.locale = 'en'
-  end
   it "has a ID" do
     creator = described_class.create(display_name: "Allen, Stephen G.")
     expect(creator.id).not_to be nil

--- a/spec/requests/creator_authority_request_spec.rb
+++ b/spec/requests/creator_authority_request_spec.rb
@@ -6,19 +6,10 @@ describe 'Creator authority', type: :request, clean: true do
   before do
     creator_array = [
       { "id": "http://id.loc.gov/authorities/names/no2003126550", "label": "Cagetti, Marco", "active": true },
-      { "id": "http://id.loc.gov/authorities/names/no2003126550", "label": "Cagetti, NotThisOne", "active": false },
+      { "id": "http://id.loc.gov/authorities/names/no2003126550", "label": "Cagetti, NotThisOne", "active": false }, # NOTE: This one should be inactive
       { "id": "https://ideas.repec.org/f/pca1299.html", "label": "Cai, Zhifeng", "active": true },
       { "id": "https://ideas.repec.org/e/pca150.html", "label": "Calsamiglia, Caterina", "active": true },
-      { "id": "https://ideas.repec.org/f/pca694.html", "label": "Calvo, Guillermo A.", "active": true },
-      { "id": "https://ideas.repec.org/f/pca371.html", "label": "Camargo, Braz", "active": true },
-      { "id": "https://ideas.repec.org/e/pca89.html", "label": "Campbell, Jeffrey R.", "active": true },
-      { "id": "https://ideas.repec.org/e/pca50.html", "label": "Canova, Fabio", "active": true },
-      { "id": "https://ideas.repec.org/e/pca77.html", "label": "Caplin, Andrew", "active": true },
-      { "id": "https://ideas.repec.org/f/pca1029.html", "label": "Carapella, Francesca", "active": true },
-      { "id": "https://ideas.repec.org/e/pca42.html", "label": "Carlstrom, Charles T., 1960-", "active": true },
-      { "id": "https://ideas.repec.org/f/pca205.html", "label": "Caselli, Francesco, 1966-", "active": true },
-      { "id": "https://ideas.repec.org/e/pca73.html", "label": "Caucutt, Elizabeth M. (Elizabeth Miriam)", "active": true },
-      { "id": "https://ideas.repec.org/f/pca963.html", "label": "Cavalcanti, Ricardo de Oliveira", "active": true }
+      { "id": "https://ideas.repec.org/f/pca694.html", "label": "Calvo, Guillermo A.", "active": true }
     ]
     creator_array.each do |creator|
       Creator.create!(
@@ -29,20 +20,20 @@ describe 'Creator authority', type: :request, clean: true do
   end
 
   describe "GET /authorities/search/creator_authority" do
-    it "returns http success" do
+    it "returns http success and only active creators" do
       get "/authorities/search/creator_authority?q=Ca"
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq "application/json"
       json_body = JSON.parse(response.body)
-      expect(json_body.count).to eq 13
+      expect(json_body.count).to eq 4
       expect(json_body.first["label"]).to eq "Cagetti, Marco"
     end
     it "returns fewer responses for a longer string" do
-      get "/authorities/search/creator_authority?q=Cam"
+      get "/authorities/search/creator_authority?q=Cal"
       expect(response).to have_http_status(:success)
       json_body = JSON.parse(response.body)
       expect(json_body.count).to eq 2
-      expect(json_body.first["label"]).to eq "Camargo, Braz"
+      expect(json_body.first["label"]).to eq "Calsamiglia, Caterina"
     end
   end
 
@@ -72,11 +63,11 @@ describe 'Creator authority', type: :request, clean: true do
   end
 
   describe "GET /authorities/terms/creator_authority" do
-    it "can show all the creators in a list" do
+    it "can show all the creators in a list, including inactive ones" do
       get "/authorities/terms/creator_authority"
       expect(response).to have_http_status(:success)
       json_body = JSON.parse(response.body)
-      expect(json_body.count).to eq 14
+      expect(json_body.count).to eq 5
       expect(json_body.first["label"]).to eq "Cagetti, Marco"
     end
   end

--- a/spec/requests/creator_authority_request_spec.rb
+++ b/spec/requests/creator_authority_request_spec.rb
@@ -5,23 +5,25 @@ require 'rails_helper'
 describe 'Creator authority', type: :request, clean: true do
   before do
     creator_array = [
-      { "id": "http://id.loc.gov/authorities/names/no2003126550", "label": "Cagetti, Marco" },
-      { "id": "https://ideas.repec.org/f/pca1299.html", "label": "Cai, Zhifeng" },
-      { "id": "https://ideas.repec.org/e/pca150.html", "label": "Calsamiglia, Caterina" },
-      { "id": "https://ideas.repec.org/f/pca694.html", "label": "Calvo, Guillermo A." },
-      { "id": "https://ideas.repec.org/f/pca371.html", "label": "Camargo, Braz" },
-      { "id": "https://ideas.repec.org/e/pca89.html", "label": "Campbell, Jeffrey R." },
-      { "id": "https://ideas.repec.org/e/pca50.html", "label": "Canova, Fabio" },
-      { "id": "https://ideas.repec.org/e/pca77.html", "label": "Caplin, Andrew" },
-      { "id": "https://ideas.repec.org/f/pca1029.html", "label": "Carapella, Francesca" },
-      { "id": "https://ideas.repec.org/e/pca42.html", "label": "Carlstrom, Charles T., 1960-" },
-      { "id": "https://ideas.repec.org/f/pca205.html", "label": "Caselli, Francesco, 1966-" },
-      { "id": "https://ideas.repec.org/e/pca73.html", "label": "Caucutt, Elizabeth M. (Elizabeth Miriam)" },
-      { "id": "https://ideas.repec.org/f/pca963.html", "label": "Cavalcanti, Ricardo de Oliveira" }
+      { "id": "http://id.loc.gov/authorities/names/no2003126550", "label": "Cagetti, Marco", "active": true },
+      { "id": "http://id.loc.gov/authorities/names/no2003126550", "label": "Cagetti, NotThisOne", "active": false },
+      { "id": "https://ideas.repec.org/f/pca1299.html", "label": "Cai, Zhifeng", "active": true },
+      { "id": "https://ideas.repec.org/e/pca150.html", "label": "Calsamiglia, Caterina", "active": true },
+      { "id": "https://ideas.repec.org/f/pca694.html", "label": "Calvo, Guillermo A.", "active": true },
+      { "id": "https://ideas.repec.org/f/pca371.html", "label": "Camargo, Braz", "active": true },
+      { "id": "https://ideas.repec.org/e/pca89.html", "label": "Campbell, Jeffrey R.", "active": true },
+      { "id": "https://ideas.repec.org/e/pca50.html", "label": "Canova, Fabio", "active": true },
+      { "id": "https://ideas.repec.org/e/pca77.html", "label": "Caplin, Andrew", "active": true },
+      { "id": "https://ideas.repec.org/f/pca1029.html", "label": "Carapella, Francesca", "active": true },
+      { "id": "https://ideas.repec.org/e/pca42.html", "label": "Carlstrom, Charles T., 1960-", "active": true },
+      { "id": "https://ideas.repec.org/f/pca205.html", "label": "Caselli, Francesco, 1966-", "active": true },
+      { "id": "https://ideas.repec.org/e/pca73.html", "label": "Caucutt, Elizabeth M. (Elizabeth Miriam)", "active": true },
+      { "id": "https://ideas.repec.org/f/pca963.html", "label": "Cavalcanti, Ricardo de Oliveira", "active": true }
     ]
     creator_array.each do |creator|
       Creator.create!(
-        display_name: creator[:label]
+        display_name: creator[:label],
+        active_creator: creator[:active]
       )
     end
   end
@@ -74,7 +76,7 @@ describe 'Creator authority', type: :request, clean: true do
       get "/authorities/terms/creator_authority"
       expect(response).to have_http_status(:success)
       json_body = JSON.parse(response.body)
-      expect(json_body.count).to eq 13
+      expect(json_body.count).to eq 14
       expect(json_body.first["label"]).to eq "Cagetti, Marco"
     end
   end

--- a/spec/system/create_publication_spec.rb
+++ b/spec/system/create_publication_spec.rb
@@ -33,9 +33,7 @@ RSpec.describe 'Create a Publication', type: :system, js: true, clean: true do
           { "value": "40", "label": "Cagetti, Notthisone", "active": "false" }
         ]
         creator_array.each do |creator|
-          if creator[:active].nil?
-            creator[:active] = true
-          end
+          creator[:active] = true if creator[:active].nil?
           Creator.create!(
             id: creator[:value],
             display_name: creator[:label],

--- a/spec/system/create_publication_spec.rb
+++ b/spec/system/create_publication_spec.rb
@@ -29,12 +29,17 @@ RSpec.describe 'Create a Publication', type: :system, js: true, clean: true do
           { "value": "36", "label": "Carlstrom, Charles T., 1960-" },
           { "value": "37", "label": "Caselli, Francesco, 1966-" },
           { "value": "38", "label": "Caucutt, Elizabeth M. (Elizabeth Miriam)" },
-          { "value": "39", "label": "Cavalcanti, Ricardo de Oliveira" }
+          { "value": "39", "label": "Cavalcanti, Ricardo de Oliveira" },
+          { "value": "40", "label": "Cagetti, Notthisone", "active": "false" }
         ]
         creator_array.each do |creator|
+          if creator[:active].nil?
+            creator[:active] = true
+          end
           Creator.create!(
             id: creator[:value],
-            display_name: creator[:label]
+            display_name: creator[:label],
+            active_creator: creator[:active]
           )
         end
       end
@@ -44,6 +49,7 @@ RSpec.describe 'Create a Publication', type: :system, js: true, clean: true do
         fill_in('Creator', with: 'Cag')
         expect(page).to have_content('Cagetti, Marco')
         expect(page).not_to have_content('Cai, Zhifeng')
+        expect(page).not_to have_content('Cagetti, Notthisone')
         find('.ui-menu-item-wrapper').click # Select the first item in the autocomplete list
         # expect(page).to have_content('Cagetti, Marco') # Once we select from the dropdown we still want to diplay the name
         click_link 'Files'


### PR DESCRIPTION
Modifies the "search" endpoint of the creator authority to return only active creators, which results in their exclusion from autocomplete suggestions.  The "find/show" endpoint is unmodified.  Connected to https://github.com/MPLSFedResearch/cypripedium/issues/427