### PR TITLE
Address intermittent test failure, can't find pt-BR

### DIFF
--- a/spec/models/creator_spec.rb
+++ b/spec/models/creator_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Creator, type: :model do
   before do
     I18n.locale = 'en'
   end
-  
+
   it "has a ID" do
     creator = described_class.create(display_name: "Allen, Stephen G.")
     expect(creator.id).not_to be nil

--- a/spec/models/creator_spec.rb
+++ b/spec/models/creator_spec.rb
@@ -2,6 +2,10 @@
 require 'rails_helper'
 
 RSpec.describe Creator, type: :model do
+  before do
+    I18n.locale = 'en'
+  end
+  
   it "has a ID" do
     creator = described_class.create(display_name: "Allen, Stephen G.")
     expect(creator.id).not_to be nil


### PR DESCRIPTION
See https://github.com/MPLSFedResearch/cypripedium/issues/482 
```bash
Failures:

  1) Creator doesn't allow duplicate RePEc ids
     Failure/Error:
       expect do
         described_class.create!(display_name: "Allen, Stephen Gomes", repec: "pal73")
       end.to raise_error(ActiveRecord::RecordInvalid, /Validation failed: Repec id already in the system/)
     
       expected ActiveRecord::RecordInvalid with message matching /Validation failed: Repec id already in the system/, got #<ActiveRecord::RecordInvalid: translation missing: pt-BR.activerecord.errors.messages.record_invalid> with backtrace:
         # ./spec/models/creator_spec.rb:23:in `block (3 levels) in <top (required)>'
         # ./spec/models/creator_spec.rb:22:in `block (2 levels) in <top (required)>'
     # ./spec/models/creator_spec.rb:22:in `block (2 levels) in <top (required)>'

  2) Creator doesn't allow a blank display_name
     Failure/Error:
       expect do
         described_class.create!(display_name: "")
       end.to raise_error(ActiveRecord::RecordInvalid, /Validation failed: Display name can't be blank/)
     
       expected ActiveRecord::RecordInvalid with message matching /Validation failed: Display name can't be blank/, got #<ActiveRecord::RecordInvalid: translation missing: pt-BR.activerecord.errors.messages.record_invalid> with backtrace:
         # ./spec/models/creator_spec.rb:17:in `block (3 levels) in <top (required)>'
         # ./spec/models/creator_spec.rb:16:in `block (2 levels) in <top (required)>'
     # ./spec/models/creator_spec.rb:16:in `block (2 levels) in <top (required)>'

  3) Creator doesn't allow duplicate VIAF ids
     Failure/Error:
       expect do
         described_class.create!(display_name: "Allen, Stephen Gomes", viaf: "789875")
       end.to raise_error(ActiveRecord::RecordInvalid, /Validation failed: Viaf id already in the system/)
     
       expected ActiveRecord::RecordInvalid with message matching /Validation failed: Viaf id already in the system/, got #<ActiveRecord::RecordInvalid: translation missing: pt-BR.activerecord.errors.messages.record_invalid> with backtrace:
         # ./spec/models/creator_spec.rb:29:in `block (3 levels) in <top (required)>'
         # ./spec/models/creator_spec.rb:28:in `block (2 levels) in <top (required)>'
     # ./spec/models/creator_spec.rb:28:in `block (2 levels) in <top (required)>'

  4) Creator doesn't allow an empty display_name
     Failure/Error:
       expect do
         described_class.create!
       end.to raise_error(ActiveRecord::RecordInvalid, /Validation failed: Display name can't be blank/)
     
       expected ActiveRecord::RecordInvalid with message matching /Validation failed: Display name can't be blank/, got #<ActiveRecord::RecordInvalid: translation missing: pt-BR.activerecord.errors.messages.record_invalid> with backtrace:
         # ./spec/models/creator_spec.rb:12:in `block (3 levels) in <top (required)>'
         # ./spec/models/creator_spec.rb:11:in `block (2 levels) in <top (required)>'
     # ./spec/models/creator_spec.rb:11:in `block (2 levels) in <top (required)>'
```