### PR TITLE
Three step creator migration process

### DIFF
--- a/lib/tasks/creator_seed.rake
+++ b/lib/tasks/creator_seed.rake
@@ -7,7 +7,7 @@ namespace :creators do
 
     solr = Blacklight.default_index.connection
 
-    response = solr.get 'select', params: { "facet.field": ["creator_sim"], "facet.limit":-1 }
+    response = solr.get 'select', params: { "facet.field": ["creator_sim"], "facet.limit": -1 }
     creators_array = response["facet_counts"]["facet_fields"]["creator_sim"]
 
     CSV.open(creators_path, 'w', write_headers: true, headers: ["display_name", "result_count"]) do |row|
@@ -43,7 +43,6 @@ namespace :creators do
     models_to_reindex = Hyrax.config.curation_concerns
     models_to_reindex.each do |klass|
       rows = klass.count
-
 
       records = ids_list(klass, rows).map { |id| ActiveFedora::Base.find(id) }
       puts "Migrating creators for #{records.count} out of #{klass.count} #{klass} records: #{Time.zone.now.localtime}"

--- a/lib/tasks/creator_seed.rake
+++ b/lib/tasks/creator_seed.rake
@@ -25,7 +25,7 @@ namespace :creators do
     creators = CSV.read(creators_path, headers: true)
     creators.each do |row|
       Creator.where(display_name: row["display_name"]).first_or_create do |creator|
-        creator.display_name = row["display_name"]
+        creator.display_name = row["display_name"].strip
         puts "Authority entry created #{creator.display_name}"
       end
     end
@@ -49,10 +49,11 @@ namespace :creators do
         next unless ActiveFedora::Base.exists?(id)
         record = ActiveFedora::Base.find(id)
         next if record.creator.empty?
+        next unless record.creator_id.empty?
         puts "Record id: #{id}"
         record.creator.each do |creator|
           puts "Creator name: #{creator}"
-          creator_identifier = creators_array.find { |ca| ca[:name] == creator }[:id]
+          creator_identifier = creators_array.find { |ca| ca[:name] == creator.strip }[:id]
           record.creator_id = record.creator_id + [creator_identifier.to_s]
         end
         record.save
@@ -70,3 +71,6 @@ def ids_list(model, rows)
   results = solr.select(query)
   results['response']['docs'].flat_map(&:values)
 end
+
+# Record id: 12579s34s
+# Creator name: McCandless Jr., George T.

--- a/lib/tasks/creator_seed.rake
+++ b/lib/tasks/creator_seed.rake
@@ -35,12 +35,15 @@ namespace :creators do
 
   desc "Go through all Fedora records and add creator_ids associated with creators"
   task migrate: :environment do
+    $stdout.sync = true # Flush output immediately
+
+    start_time = Time.zone.now.localtime
     creators_array = Creator.pluck(:id, :display_name).map { |id, name| { id: id, name: name } }
 
     models_to_reindex = Hyrax.config.curation_concerns
     models_to_reindex.each do |klass|
       rows = klass.count
-      puts "Re-indexing #{klass.count} #{klass} records: #{Time.zone.now.localtime}"
+      puts "Migrating #{klass.count} creators for #{klass} records: #{Time.zone.now.localtime}"
 
       id_list(klass, rows).each do |id|
         next unless ActiveFedora::Base.exists?(id)
@@ -54,10 +57,9 @@ namespace :creators do
         end
         record.save
       end
-
-      end_time = Time.zone.now.localtime
-      puts "Re-index finished at: #{end_time}"
-      printf "Re-index finished in: %0.1f minutes \n", time_in_minutes(start_time, end_time)
     end
+    end_time = Time.zone.now.localtime
+    puts "Creator migration finished at: #{end_time}"
+    printf "Creator migration finished in: %0.1f minutes \n", time_in_minutes(start_time, end_time)
   end
 end

--- a/lib/tasks/creator_seed.rake
+++ b/lib/tasks/creator_seed.rake
@@ -45,7 +45,7 @@ namespace :creators do
       rows = klass.count
       puts "Migrating #{klass.count} creators for #{klass} records: #{Time.zone.now.localtime}"
 
-      id_list(klass, rows).each do |id|
+      ids_list(klass, rows).each do |id|
         next unless ActiveFedora::Base.exists?(id)
         record = ActiveFedora::Base.find(id)
         next if record.creator.empty?
@@ -62,4 +62,11 @@ namespace :creators do
     puts "Creator migration finished at: #{end_time}"
     printf "Creator migration finished in: %0.1f minutes \n", time_in_minutes(start_time, end_time)
   end
+end
+
+# Have to override reindex id_list method to filter out Private works, which are creating errors
+def ids_list(model, rows)
+  query = { params: { q: "has_model_ssim:#{model}", fq: "visibility_ssi:open", fl: "id", rows: rows } }
+  results = solr.select(query)
+  results['response']['docs'].flat_map(&:values)
 end

--- a/lib/tasks/creator_seed.rake
+++ b/lib/tasks/creator_seed.rake
@@ -1,17 +1,62 @@
 # frozen_string_literal: true
 require "csv"
-namespace :vocab do
+namespace :creators do
+  desc "Collects creator names and saves them to csv"
+  task collect: :environment do
+    creators_path = Rails.root.join("data", "creators.csv")
+
+    solr = Blacklight.default_index.connection
+
+    response = solr.get 'select', params: { "facet.field": ["creator_sim"] }
+    creators_array = response["facet_counts"]["facet_fields"]["creator_sim"]
+
+    # Option one - just returns the creator names in an array, taking out the number of records
+    # creators_array.map { |a| a if a.is_a? String }.compact
+    CSV.open(creators_path,'w',
+        :write_headers=> true,
+        :headers => ["display_name", "result_count"] #< column header
+      ) do|row|
+        creators_array.each_slice(2) do |pair|
+          row << pair
+        end
+    end
+  end
+
   desc "Create database-based local authorities"
   task create: :environment do
     creators_path = Rails.root.join("data", "creators.csv")
-    creators = CSV.read(creators_path, headers: false)
+    creators = CSV.read(creators_path, headers: true)
     creators.each do |row|
-      Creator.where(display_name: row.first).first_or_create do |creator|
-        creator.display_name = row.first
+      Creator.where(display_name: row["display_name"]).first_or_create do |creator|
+        creator.display_name = row["display_name"]
         puts "Authority entry created #{creator.display_name}"
       end
     end
 
     puts Creator.count.to_s
+  end
+
+  desc "Go through all Fedora records and add creator_ids associated with creators"
+  task migrate: :environment do
+    creators_array = Creator.pluck(:id, :display_name).map { |id, name| { id: id, name: name } }
+    solr = Blacklight.default_index.connection
+
+    models_to_reindex = [::Collection] + Hyrax.config.curation_concerns
+    models_to_reindex.each do |klass|
+      rows = klass.count
+      puts "Re-indexing #{klass.count} #{klass} records: #{Time.zone.now.localtime}"
+
+      id_list(klass, rows).each do |id|
+        next unless ActiveFedora::Base.exists?(id)
+        record = ActiveFedora::Base.find(id)
+        next if record.creator.empty?
+        record.creator.each do |creator|
+          creator_identifier = creators_array.select {|ca| ca[:name] == creator }.first[:id]
+          record.creator_id = record.creator_id + [creator_identifier.to_s]
+          record.save
+        end
+        record.update_index
+      end
+    end
   end
 end


### PR DESCRIPTION
Here's the basic idea:

- on the target system (once tested)
  - `rake creators:collect`
    - This will run a facet search against Solr for all creator names on the system, and save them to a csv file, along with the record count for that creator name
  - `rake creators:create`
    - This will open the csv file created in the previous step, and for each line in the csv, make a Creator in the database
  - `rake creators:migrate`
    - This steals some from the existing reindexing rake task. Iterates through all the Work types and adds a creator_id 