### PR TITLE
Remove destroy button

### DIFF
--- a/app/views/creators/_list_active_creators.html.erb
+++ b/app/views/creators/_list_active_creators.html.erb
@@ -16,7 +16,6 @@
           <td><%= link_to 'Show', creator %></td>
           <% if current_or_guest_user.can?(:edit, Creator) %>
             <td><%= link_to 'Edit', edit_creator_path(creator) %></td>
-            <td><%= link_to 'Destroy', creator, method: :delete, data: { confirm: 'Are you sure?' } %></td>
           <% end %>
         </tr>
       <% end %>

--- a/spec/models/creator_spec.rb
+++ b/spec/models/creator_spec.rb
@@ -2,6 +2,9 @@
 require 'rails_helper'
 
 RSpec.describe Creator, type: :model do
+  before do
+    I18n.locale = 'en'
+  end
   it "has a ID" do
     creator = described_class.create(display_name: "Allen, Stephen G.")
     expect(creator.id).not_to be nil

--- a/spec/system/creator_spec.rb
+++ b/spec/system/creator_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe 'Creators', type: :system, js: true do
       expect(page).to have_content(/active/i, count: 1)
       expect(page).to have_content("true")
       expect(page).to have_content("false")
+      expect(page).not_to have_link("Destroy")
     end
     it "can create a new creator record" do
       visit "/creators/new"


### PR DESCRIPTION
We generally don't want to delete authority records, so we're removing this option from the UI (but not from the core code itself).  Users should generally use the Edit item functionality to deactivate a record in the authority so that we don't invalidate existing reference to the authority.