### PR TITLE
Address intermittent test failure

### DIFF
--- a/spec/system/bag_export_spec.rb
+++ b/spec/system/bag_export_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'Bagit export:', type: :system, js: true do
     before do
       ActiveJob::Base.queue_adapter = :test
       [publication, data_set] # Create the records
+      I18n.locale = 'en'
     end
 
     it 'queues the bagit job' do


### PR DESCRIPTION
See https://app.circleci.com/pipelines/github/MPLSFedResearch/cypripedium/332/workflows/d22cc963-7f17-454c-b2db-ced7db77b7c8/jobs/334/tests#failed-test-0 

```
Failure/Error: expect(page).to have_current_path(Hyrax::Engine.routes.url_helpers.notifications_path(locale: I18n.locale))
  expected "/notifications?locale=en" to equal "/notifications?locale=pt-BR"

[Screenshot]: tmp/screenshots/failures_r_spec_example_groups_bagit_export_exporting_a_bag_queues_the_bagit_job_672.png


./spec/system/bag_export_spec.rb:45:in `block (3 levels) in <top (required)>'
```