### PR TITLE
Added redis info into readme file and ignored .ruby-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ fits.log
 .byebug_history
 .env*
 .idea/*
+.ruby-version
+dump.rdb

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The best way to know that your local development environment is running as expec
 3. Run `solr_wrapper`; check in your browser at `localhost:8983/solr` to see it running.
 4. Run `fcrepo_wrapper`; check in your browser at `localhost:8984/rest` to see it running.
 5. Run `sidekiq`. You can see it running at localhost:3000/sidekiq
-6. Run `redis-server`; Reids will run, you can check redis running by running `redis-cli ping` in a new window
+6. Run `redis-server`; Redis will run, you can check redis running by running `redis-cli ping` in a new window
 
 ## Data setup
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The best way to know that your local development environment is running as expec
 3. Run `solr_wrapper`; check in your browser at `localhost:8983/solr` to see it running.
 4. Run `fcrepo_wrapper`; check in your browser at `localhost:8984/rest` to see it running.
 5. Run `sidekiq`. You can see it running at localhost:3000/sidekiq
+6. Run `redis-server`; Reids will run, you can check redis running by running `redis-cli ping` in a new window
 
 ## Data setup
 


### PR DESCRIPTION
1. Added info about starting redis when starting the Hyrax application. 
2. Ignored the ruby version file .ruby-version.