### PR TITLE
Set hyrax analytics config to false

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -41,7 +41,7 @@ Hyrax.config do |config|
   # Enable displaying usage statistics in the UI
   # Defaults to false
   # Requires a Google Analytics id and OAuth2 keyfile.  See README for more info
-  # config.analytics = false
+  config.analytics = false
 
   # Google Analytics tracking ID to gather usage statistics
   config.google_analytics_id = 'UA-131289387-1'


### PR DESCRIPTION
This configuration is set to false so that the analytics sidebar will not display. The logic for this configuration is already in the sidebar but it was commented out. 