### PR TITLE
Simplify Capistrano / Sidekiq integration

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -10,8 +10,13 @@ require "capistrano/deploy"
 require 'capistrano/bundler'
 
 require 'capistrano/rails'
-require 'capistrano/sidekiq'
 require 'capistrano/passenger'
+
+# Sidekiq integration - https://github.com/seuros/capistrano-sidekiq
+require 'capistrano/sidekiq'
+install_plugin Capistrano::Sidekiq # Default sidekiq tasks
+install_plugin Capistrano::Sidekiq::Systemd
+set :sidekiq_service_unit_user, :system # Run Sidekiq as a system service
 
 # Load the SCM plugin appropriate to your project:
 #

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'whenever', require: false
 
 group :development do
   gem 'capistrano-passenger'
-  gem 'capistrano-sidekiq', '~> 0.20.0'
+  gem 'capistrano-sidekiq'
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'pry'
   gem 'pry-doc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
-    airbrussh (1.4.0)
+    airbrussh (1.5.1)
       sshkit (>= 1.6.1, != 1.7.0)
     almond-rails (0.3.0)
       rails (>= 4.2)
@@ -161,7 +161,7 @@ GEM
       thor
     byebug (11.1.3)
     cancancan (1.17.0)
-    capistrano (3.17.0)
+    capistrano (3.18.0)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -175,9 +175,10 @@ GEM
     capistrano-rails (1.5.0)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
-    capistrano-sidekiq (0.20.0)
+    capistrano-sidekiq (2.3.1)
       capistrano (>= 3.9.0)
-      sidekiq (>= 3.4)
+      capistrano-bundler
+      sidekiq (>= 6.0)
     capybara (3.39.2)
       addressable
       matrix
@@ -603,6 +604,7 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.3.0)
+    mutex_m (0.2.0)
     nest (3.2.0)
       redic
     net-http-persistent (4.0.2)
@@ -614,11 +616,13 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-scp (3.0.0)
-      net-ssh (>= 2.6.5, < 7.0.0)
+    net-scp (4.0.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
     net-smtp (0.4.0.1)
       net-protocol
-    net-ssh (6.1.0)
+    net-ssh (7.2.1)
     nio4r (2.7.0)
     noid (0.9.0)
     noid-rails (3.0.3)
@@ -784,6 +788,8 @@ GEM
     redis-activesupport (5.2.0)
       activesupport (>= 3, < 7)
       redis-store (>= 1.3, < 2)
+    redis-client (0.19.1)
+      connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)
     redis-store (1.6.0)
@@ -902,10 +908,11 @@ GEM
       rdf-xsd (~> 3.1)
       sparql (~> 3.1)
       sxp (~> 1.1)
-    sidekiq (6.5.10)
-      connection_pool (>= 2.2.5, < 3)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
+    sidekiq (7.2.0)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.14.0)
     signet (0.18.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -961,8 +968,10 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sshkit (1.21.2)
+    sshkit (1.22.0)
+      mutex_m
       net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
     ssrf_filter (1.0.8)
     sxp (1.2.4)
@@ -1063,7 +1072,7 @@ DEPENDENCIES
   capistrano-ext
   capistrano-passenger
   capistrano-rails
-  capistrano-sidekiq (~> 0.20.0)
+  capistrano-sidekiq
   capybara
   coffee-rails (~> 4.2)
   coveralls

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # config valid only for current version of Capistrano
-lock "3.17.0"
+lock "3.18.0"
 
 set :application, "cypripedium"
 set :repo_url, "https://github.com/MPLSFedResearch/cypripedium.git"
@@ -38,30 +38,6 @@ namespace :hyrax do
           execute :rake, 'hyrax:default_admin_set:create'
         end
       end
-    end
-  end
-end
-
-# We have to re-define capistrano-sidekiq's tasks to work with
-# systemctl in production. Note that you must clear the previously-defined
-# tasks before re-defining them.
-Rake::Task["sidekiq:stop"].clear_actions
-Rake::Task["sidekiq:start"].clear_actions
-Rake::Task["sidekiq:restart"].clear_actions
-namespace :sidekiq do
-  task :stop do
-    on roles(:app) do
-      execute :sudo, :systemctl, :stop, :sidekiq
-    end
-  end
-  task :start do
-    on roles(:app) do
-      execute :sudo, :systemctl, :start, :sidekiq
-    end
-  end
-  task :restart do
-    on roles(:app) do
-      execute :sudo, :systemctl, :restart, :sidekiq
     end
   end
 end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-# deploys to FRBM AWS production
-set :stage, :production
-set :rails_env, 'production'
-server '3.208.81.15', user: 'deploy', roles: [:web, :app, :db]

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-# deploys to FRBM AWS qa
-set :stage, :qa
-set :rails_env, 'production'
-server '54.164.99.127', user: 'deploy', roles: [:web, :app, :db]

--- a/config/deploy/ssm.rb
+++ b/config/deploy/ssm.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
-# deploys to FRBM AWS production
+# deploys to FRBM AWS Gov Cloud instances vis SSM
+# defaults to staging environment
+# To set a target environment, the instance must be tagged in Gov Cloud:
+#   Project=rdb
+#   Environment=prod | stage | qa | etc.
+# Invoke the deploy command with the HOST_ENV variable specifying the desired environment, e.g.
+#   HOST_ENV=prod bundle exec cap ssm deploy
+
 require 'net/ssh/proxy/command'
 set :stage, :production
-set :host_env, -> { ENV['host_env'] || 'prod' }
+set :host_env, -> { ENV['HOST_ENV'] || 'stage' }
 set :instance_id, lambda {
   `aws ec2 describe-instances --region us-gov-east-1  --profile frbm-ssm \
                        --filters Name=tag-key,Values=Environment Name=tag-value,Values=#{fetch(:host_env)} Name=instance-state-name,Values=running \

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-# deploys to FRBM AWS staging
-set :stage, :staging
-set :rails_env, 'production'
-server '18.211.59.195', user: 'deploy', roles: [:web, :app, :db]


### PR DESCRIPTION
This change updates the capistrano-sidekiq gem and removes obsolete configuration that is now handled by the gem.

We've also removed capistrano stages for vanilla EC2 instances because all deployments must now occur via SSM to Gov Cloud.