### PR TITLE
Downgrade Sidekiq for Rails 5.x compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'rsolr', '>= 1.0'
 gem 'rubyzip', '~> 1.0', require: 'zip'
 gem 'sass-rails', '~> 5.0'
 gem 'sassc-rails', '>= 2.1.0'
-gem 'sidekiq'
+gem 'sidekiq', '< 7'
 gem 'simple_form', ">= 5.0.0"
 gem 'solrizer'
 gem 'terser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -769,8 +769,6 @@ GEM
     redis-activesupport (5.2.0)
       activesupport (>= 3, < 7)
       redis-store (>= 1.3, < 2)
-    redis-client (0.19.1)
-      connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)
     redis-store (1.6.0)
@@ -886,11 +884,10 @@ GEM
       rdf-xsd (~> 3.1)
       sparql (~> 3.1)
       sxp (~> 1.1)
-    sidekiq (7.2.0)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.14.0)
+    sidekiq (6.5.12)
+      connection_pool (>= 2.2.5, < 3)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
     signet (0.18.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -1077,7 +1074,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sassc-rails (>= 2.1.0)
   selenium-webdriver
-  sidekiq
+  sidekiq (< 7)
   simple_form (>= 5.0.0)
   solr_wrapper
   solrizer


### PR DESCRIPTION
Sidekiq 7.x requires Rails 6.x or above - see
https://github.com/sidekiq/sidekiq/blob/main/docs/7.0-Upgrade.md#version-support

This change ensures that we continue to use a version of Sidekiq that is compatible with Rails 5.x