### PR TITLE
Implement a modal citations dialog

### DIFF
--- a/app/assets/stylesheets/citations.scss
+++ b/app/assets/stylesheets/citations.scss
@@ -1,0 +1,11 @@
+.citation-header h3 {
+  line-height: 1rem;
+}
+
+.chicago-citation, .mla-citation, .apa-citation {
+  margin-bottom: 3rem;
+
+  h4 {
+    margin-bottom: 0.5rem;
+  }
+}

--- a/app/views/hyrax/base/_citations.html.erb
+++ b/app/views/hyrax/base/_citations.html.erb
@@ -1,15 +1,13 @@
 <div class="citations">
-    <% if Hyrax.config.citations? %>
-      <%= link_to "Citations", hyrax.citations_work_path(presenter), id: 'citations', class: 'btn btn-default' %>
-    <% end %>
-    <div class="btn-group">
-      <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        <%= t('.header') %> <span class="caret"></span>
-      </button>
-      <ul class="dropdown-menu">
-        <li><%= link_to 'EndNote', polymorphic_path([main_app, presenter], format: 'endnote') %></li>
-        <li><%= link_to 'Chicago', "/works/#{presenter.id}/citation?output=chicago",   id: 'chicagoLink', name: 'chicago' %></li>
-        <li><%= link_to 'MLA', "/works/#{presenter.id}/citation?output=mla",   id: 'mlaLink', name: 'mla' %></li>
-      </ul>
-    </div>
+  <%= link_to t('blacklight.tools.citation'), '#citation_examples',  {'data-toggle' =>  'modal', 'data-target' => '#citation_examples', class: 'btn btn-default'}  %>
+  <%= link_to t('hyrax.base.citations.endnote'), polymorphic_path([main_app, presenter], format: 'endnote'), class: 'btn btn-default' %>
 </div>
+
+<div id="citation_examples" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="citation_examples" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <%= render template: 'hyrax/citations/work' %>
+    </div>
+  </div>
+</div>
+

--- a/app/views/hyrax/citations/work.html.erb
+++ b/app/views/hyrax/citations/work.html.erb
@@ -1,14 +1,34 @@
-<h4>Citation Formats</h4>
+<div class="modal-header citation-header">
+  <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
+    <span aria-hidden="true">&times;</span>
+  </button>
 
-<% if params[:output].nil? || params[:output].eql?("mla") %>
-  <h4>MLA</h4>
-  <span class="mla-citation"><%= export_as_mla_citation(@presenter) %></span>
-  <br /><br />
-<% end %>
+  <h3 class="modal-title show-header">
+    <small><span class="text-muted"><%= t('hyrax.base.citations.header') %></span></small>
+  </h3>
 
-<% if params[:output].nil? || params[:output].eql?("chicago") %>
-  <h4>Chicago</h4>
-  <span class="chicago-citation"><%= export_as_chicago_citation(@presenter) %></span>
-  <br /><br />
-<% end %>
+  <span><em><%= t('hyrax.base.citations.disclaimer') %></em></span>
+</div>
 
+<div class="modal-body">
+  <div class="chicago-citation">
+    <h4><%= t('blacklight.citation.chicago') %></h4>
+    <%= export_as_chicago_citation(@presenter) %>
+  </div>
+
+  <div class="mla-citation">
+    <h4><%= t('blacklight.citation.mla') %></h4>
+    <%= export_as_mla_citation(@presenter) %>
+  </div>
+
+  <div class="apa-citation">
+    <h4><%= t('blacklight.citation.apa') %></h4>
+    <%= export_as_apa_citation(@presenter) %>
+  </div>
+</div>
+
+<div class="modal-footer">
+  <button type="button" class="btn btn-primary" data-dismiss="modal">
+    <%= t('blacklight.modal.close') %>
+  </button>
+</div>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -45,6 +45,10 @@ de:
           title_tesim: Titel
   hyrax:
     account_name: Meine Institution Konto-ID
+    base:
+      citations:
+        disclaimer: 'Nur als Vorschlag bereitgestellt. Bitte überprüfen Sie diese automatisierten Zitate anhand der Richtlinien Ihres bevorzugten Stils.'
+        header: 'Beispielzitat'
     directory:
       suffix: "@ Example.org"
     footer:

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -100,11 +100,8 @@ en:
         creators: Creators
     base:
       citations:
-          citations: Citations
-          endnote: EndNote
-          header: 'Citation Tools'
-          mendeley: Mendeley
-          zotero: Zotero
+          disclaimer: 'Provided as a suggestion only. Please verify these automated citations against the guidelines of your preferred style.'
+          header: 'Sample Citation'
     product_name:           "Research Database"
     product_twitter_handle: "@MinneapolisFed"
     institution_name:       "Federal Reserve Bank of Minneapolis"

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -45,6 +45,10 @@ es:
           title_tesim: Título
   hyrax:
     account_name: Mi identificador de cuenta institucional
+    base:
+      citations:
+        disclaimer: 'Proporcionado sólo como sugerencia. Revise estas citas automáticas según las pautas de su estilo preferido.'
+        header: 'Cita de muestra'
     directory:
       suffix: "@example.org"
     footer:

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -45,6 +45,10 @@ fr:
           title_tesim: Titre
   hyrax:
     account_name: L'ID de compte de mon établissement
+    base:
+      citations:
+        disclaimer: 'Fourni à titre de suggestion uniquement. Veuillez examiner ces citations automatisées par rapport aux directives de votre style préféré.'
+        header: 'Exemple de citation'
     directory:
       suffix: "@ Example.org"
     footer:

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -45,6 +45,10 @@ it:
           title_tesim: Titolo
   hyrax:
     account_name: ID del mio istituto dell'istituto
+    base:
+      citations:
+        disclaimer: 'Fornito solo come suggerimento. Ti invitiamo a rivedere queste citazioni automatizzate rispetto alle linee guida del tuo stile preferito.'
+        header: 'Citazione campione'
     directory:
       suffix: "@ example.org"
     footer:

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -45,6 +45,10 @@ pt-BR:
           title_tesim: Título
   hyrax:
     account_name: ID da conta da minha instituição
+    base:
+      citations:
+        disclaimer: 'Fornecido apenas como sugestão. Revise essas citações automatizadas de acordo com as diretrizes do seu estilo preferido.'
+        header: 'Citação de amostra'
     directory:
       suffix: "@ Example.org"
     footer:

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -45,6 +45,10 @@ zh:
           title_tesim: 标题
   hyrax:
     account_name: 我的机构帐户标识符
+    base:
+      citations:
+        disclaimer: '僅作為建議提供 請根據您喜歡的風格指南查看這些自動引用'
+        header: '引用樣本'
     directory:
       suffix: "@example.org"
     footer:


### PR DESCRIPTION
**STORY**
As a user, I want to remain in the context of the work I'm viewing while I access citations, instead of being taken to a different page that does not have navigation links back to my work.

**SOLUTION**
Implement citations as a modal pop up on the work's main show page instead of linking to a separate citation page.

NOTES:
1. Users could get back to the work page using their browser back button, but the previous UI did not provide clear navigational hints.
2. This fix implements Hyrax's default citations for Chicago, MLA, and APA styles.  Additional customizations are required to update the citation formatters to display Cypripedium specific metadata.

REFERENCES:
This work was highly influenced by:
* Citation work by Brad Watson at Emory Libraries https://github.com/emory-libraries/dlp-lux/commit/006688cd05e2c9361eb018f0424616d4903e1ce9
* Bootstrap documentation https://getbootstrap.com/docs/5.2/components/modal/
* This CodePen by Moshe Assayag https://codepen.io/mozez/pen/rYXBvZ