### PR TITLE
Clean up Internationalization locale management

### DIFF
--- a/app/controllers/bag_controller.rb
+++ b/app/controllers/bag_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class BagController < ApplicationController
-  before_action :set_locale
   ALLOWED_EXTENSIONS = ['zip', 'tar'].freeze
 
   def download

--- a/app/controllers/creators_controller.rb
+++ b/app/controllers/creators_controller.rb
@@ -4,7 +4,6 @@ class CreatorsController < ApplicationController
   load_and_authorize_resource
   before_action :set_creator, only: [:show, :edit, :update, :destroy]
   before_action :pick_theme
-  before_action :set_locale
 
   def pick_theme
     if current_user&.admin?

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -12,7 +12,7 @@
 <% end %>
 
 <% if can? :read, :admin_dashboard %>
-  <%= menu.nav_link("/creators?locale=en") do %>
+  <%= menu.nav_link(main_app.creators_path) do %>
     <span class="fa fa-flag" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('creators.index.manage_creators') %></span>
   <% end %>
 

--- a/spec/models/creator_spec.rb
+++ b/spec/models/creator_spec.rb
@@ -2,9 +2,6 @@
 require 'rails_helper'
 
 RSpec.describe Creator, type: :model do
-  before do
-    I18n.locale = 'en'
-  end
   it "has a ID" do
     creator = described_class.create(display_name: "Allen, Stephen G.")
     expect(creator.id).not_to be nil

--- a/spec/system/404_spec.rb
+++ b/spec/system/404_spec.rb
@@ -3,8 +3,11 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.describe 'Getting a 404 for RecordNotFound', type: :system do
-  before do
+  after do
+    # Reset the locale after any tests that use an explicit locale
+    I18n.locale = I18n.default_locale
   end
+
   context 'visiting a work that does not exist' do
     it 'has a 404 page' do
       visit('/concern/works/s7526c41m?locale=pt-BR')

--- a/spec/system/bag_export_spec.rb
+++ b/spec/system/bag_export_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe 'Bagit export:', type: :system, js: true do
     before do
       ActiveJob::Base.queue_adapter = :test
       [publication, data_set] # Create the records
-      I18n.locale = 'en'
     end
 
     xit 'queues the bagit job' do

--- a/spec/system/invalid_locale_spec.rb
+++ b/spec/system/invalid_locale_spec.rb
@@ -3,9 +3,11 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.describe 'Getting a friendly error for Invalid Locales', type: :system do
-  # The empty before block allows these tests to pass in CI
-  before do
+  after do
+    # Reset the locale after any tests that use an explicit locale
+    I18n.locale = I18n.default_locale
   end
+
   context 'visiting a locale that does not exist' do
     it 'has a 406 page' do
       visit('/?locale=pluto')


### PR DESCRIPTION
**ISSUES**
* Calls to `:set_locale` are redundant - this behavior is included in all controllers that inherit from the `ApplicationController` via the inclusion of `Hyrax::Controller`
* Other references that set the locale explicitly are probably attempting to correct for tests that change the locale and don't reset it afterwards, so we have identified those tests and ensured they reset the locale set to the default_locale for any following tests.