### PR TITLE
Fix database schema and migration chain

### DIFF
--- a/db/migrate/20230208230723_create_user_collections.rb
+++ b/db/migrate/20230208230723_create_user_collections.rb
@@ -1,0 +1,11 @@
+class CreateUserCollections < ActiveRecord::Migration[5.2]
+  def change
+    create_table :user_collections do |t|
+      t.string :email, :null => false, :uniqueness => true
+      t.text :collections, default: [].to_yaml
+
+      t.timestamps
+    end
+    add_index :user_collections, :email
+  end
+end

--- a/db/migrate/20240117203355_drop_user_collections.rb
+++ b/db/migrate/20240117203355_drop_user_collections.rb
@@ -1,0 +1,15 @@
+class DropUserCollections < ActiveRecord::Migration[5.2]
+  def up
+    drop_table :user_collections
+  end
+
+  def down
+    create_table :user_collections do |t|
+      t.string :email, :null => false, :uniqueness => true
+      t.text :collections, default: [].to_yaml
+
+      t.timestamps
+    end
+    add_index :user_collections, :email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210426173022) do
+ActiveRecord::Schema.define(version: 2024_01_17_203355) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -147,6 +147,12 @@ ActiveRecord::Schema.define(version: 20210426173022) do
     t.boolean "brandable", default: true, null: false
     t.string "badge_color", default: "#663333"
     t.index ["machine_id"], name: "index_hyrax_collection_types_on_machine_id", unique: true
+  end
+
+  create_table "hyrax_default_administrative_set", force: :cascade do |t|
+    t.string "default_admin_set_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "hyrax_features", id: :serial, force: :cascade do |t|
@@ -316,9 +322,9 @@ ActiveRecord::Schema.define(version: 20210426173022) do
   end
 
   create_table "single_use_links", id: :serial, force: :cascade do |t|
-    t.string "downloadKey"
+    t.string "download_key"
     t.string "path"
-    t.string "itemId"
+    t.string "item_id"
     t.datetime "expires"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -356,7 +362,7 @@ ActiveRecord::Schema.define(version: 20210426173022) do
 
   create_table "sipity_entity_specific_responsibilities", id: :serial, force: :cascade do |t|
     t.integer "workflow_role_id", null: false
-    t.string "entity_id", null: false
+    t.integer "entity_id", null: false
     t.integer "agent_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
**ISSUE**
There was a migration included in the code that was recently reverted. Additionally, the schema file had manual edits that didn't correspond to any migrations.

We want to return the schema to a clean state and ensure that the migration chain is reversible for servers that have had the reverted migration deployed.

**SOLUTION**
Re-instantiate the unwanted migration and add an explicit migration to undo its changes.  This allows us to apply the migrations to any production-like environment without having to manually rollback.

This commit also includes a 'clean' schema that removes any manual edits.