### PR TITLE
Add support for additional resource type citations

### DIFF
--- a/app/presenters/cypripedium/citation_formatter.rb
+++ b/app/presenters/cypripedium/citation_formatter.rb
@@ -2,6 +2,8 @@
 
 module Cypripedium
   module CitationFormatter
+    include Cypripedium::CitationTypeMapper
+
     def apa_citation
       citation_for('apa')
     end
@@ -24,7 +26,7 @@ module Cypripedium
 
     # Return a CiteProc::Item constructed from the presenter metadata
     def item
-      CiteProc::Item.new(citation_item)
+      @item ||= CiteProc::Item.new(citation_item)
     end
 
     # Hash of metadata required to construct citations
@@ -34,22 +36,70 @@ module Cypripedium
     def citation_item
       {
         id: :item,
-        type: 'paper',
+        type: citation_type,
         title: title&.first,
         author: creators_for_citation,
-        'collection-title': collection_for_citation,
-        'collection-number': issue_number&.first,
+        volume: volume_number_for_citation,
+        issue: issue_number_for_citation,
         URL: url,
-        publisher: 'Federal Reserve Bank of Minneapolis, Minneapolis, MN',
+        publisher: publisher&.first || 'Federal Reserve Bank of Minneapolis, Minneapolis, MN',
         # 'publisher-place': 'Minneapolis, MN',
-        issued: date_created&.first.to_i
-      }
+        issued: date_for_citation
+      }.merge(type_specific_data)
+    end
+
+    def type_specific_data
+      case citation_type
+      when 'article-journal'
+        # container-title gets italicized, collection-title does not
+        { 'container-title' => series_for_citation }
+      when 'paper-conference'
+        { 'collection-title' => conference_details,
+          'publisher' => nil } # publisher is inlcuded in comma separated sponsor info in conference details instead
+      when 'manuscript', 'dataset'
+        { 'collection-title' => [dataset_label, series_for_citation].compact.join('. '),
+          'collection-number' => issue_number&.first }
+      else
+        {} # always return a hash
+      end
+    end
+
+    # Independent or supporting data
+    def dataset_label
+      return unless citation_type == 'dataset'
+
+      if issue_number || title.first.match(/additional file/i)
+        'Supporting Data'
+      else
+        'Research Database'
+      end
+    end
+
+    # Name, sponsor, and place of conference
+    def conference_details
+      ["Paper presented at the #{conference_name}",
+       'Federal Reserve Bank of Minneapolis',
+       'Minneapolis, MN'].join(', ')
+    end
+
+    # Return a conference name based on the series name
+    def conference_name
+      return series_for_citation if series&.first&.match?(/[Cc]onference/)
+
+      "#{series_for_citation} conference"
+    end
+
+    # creations date or deposit date if creation date is missing
+    def date_for_citation
+      return Date.parse(date_uploaded).year if date_created.blank?
+
+      date_created.first.to_i
     end
 
     # Return the doi or other uri when present,
     # otherwise return a fallback url
     def url
-      @url ||= identifier.find { |id| id.match(/http|doi/) } || fallback_url
+      identifier.find { |id| id.match(/http|doi/) } || fallback_url
     end
 
     # Return the canonical url for the item
@@ -57,15 +107,43 @@ module Cypripedium
       Rails.application.routes.url_helpers.url_for([self, { host: request.base_url }])
     end
 
+    # Sanitize creator names
     # Remove dates like 1965- or 1935-2011
     # and initial expansions like F. T. (Fancis Thomas)
+    # Examples ['Kocherlakota, Narayana Rao, 1963- ',  " \tAvenancio-León, Carlos\n",
+    #            'Juster, F. Thomas (Francis Thomas), 1926-2019', 'Wang, Ping, 1957 December 5-']
+    # returns ['Kocherlakota, Narayana Rao', 'Avenancio-León, Carlos', 'Juster, F. Thomas', 'Wang, Ping']
     def creators_for_citation
-      creator.map { |name| name.gsub(/,\s*\d{4}-(\d{4})?|\([^)]*\)/, '') }
+      creator.map { |name| name.gsub(/,\s*\d{4}.*|\([^)]*\)/, '') }
     end
 
     # Use the beginning of the series name up to the first parenthesis
-    def collection_for_citation
+    def series_for_citation
       series&.first&.split(' (')&.first
+    end
+
+    def issue_number_for_citation
+      parse_issue_and_volume[:issue]
+    end
+
+    def volume_number_for_citation
+      parse_issue_and_volume[:volume]
+    end
+
+    # extract alpha-numeric issue and volume number from issue field
+    # sample data can appear as
+    #   Vol. 16, No. 1
+    #   vol.10 no.36
+    #   no. 41
+    #   no.93
+    #   130
+    #   081
+    #   "vol.8 no.59 "
+    #   no. 54A
+    def parse_issue_and_volume
+      return { issue: nil, volume: nil } unless issue_number
+
+      @parse_issue_and_volume ||= issue_number.first.match(/^(v(ol)?\.?\s*(?<volume>\w+),?\s*)?(no\.?)?\s*(?<issue>\w+)/i)
     end
   end
 end

--- a/app/presenters/cypripedium/citation_type_mapper.rb
+++ b/app/presenters/cypripedium/citation_type_mapper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Cypripedium
+  module CitationTypeMapper
+    private
+
+    # Map resource_type to CSL citation types
+    # for a list of valid CSL types, see https://docs.citationstyles.org/en/stable/specification.html#appendix-iii-types
+    MAPPER =
+      { 'Article' => 'article-journal',
+        'Conference Proceeding' => 'paper-conference',
+        'Dataset' => 'dataset',
+        'Other' => 'dataset',
+        'Report' => 'article-journal',
+        'Research Paper' => 'manuscript',
+        'Software or Program Code' => 'dataset' }.freeze
+
+    def citation_type
+      MAPPER[resource_type&.first] || 'dataset'
+    end
+  end
+end

--- a/app/presenters/cypripedium_work_presenter.rb
+++ b/app/presenters/cypripedium_work_presenter.rb
@@ -5,7 +5,6 @@ class CypripediumWorkPresenter < Hyrax::WorkShowPresenter
 
   Attributes.to_a.each { |term| delegate term, to: :solr_document }
   delegate :alpha_creator, to: :solr_document
-  delegate :member_of_collections, to: :solr_document
 
   def work_zip
     WorkZip.latest(id).first || WorkZip.new(work_id: id)

--- a/spec/presenters/cypripedium/citation_formatter_spec.rb
+++ b/spec/presenters/cypripedium/citation_formatter_spec.rb
@@ -3,37 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe Cypripedium::CitationFormatter do
+  let(:citation) { presenter.chicago_citation }
   let(:presenter) { CypripediumWorkPresenter.new(solr_document, nil, request) }
   let(:request) { instance_double(ActionDispatch::Request, base_url: 'https://researchdatabase.minneapolisfed.org') }
   let(:solr_document) { SolrDocument.new(solr_data) }
   let(:solr_data) do
-    # multiple authors, doi, working paper
+    # minimal metadata
     {
       "has_model_ssim": ["Publication"],
       "id": "br86b3634",
-      "series_tesim": ["Working paper (Federal Reserve Bank of Minneapolis. Research Department)"],
-      "issue_number_tesim": ["636"],
-      "issue_number_ssi": "636",
-      "depositor_tesim": ["batchuser@example.com"],
       "title_tesim": ["Expensed and Sweat Equity"],
-      "date_uploaded_dtsi": "2019-06-25T13:40:30Z",
-      "date_modified_ssi": "Wed Oct 23 17:51:43 2019",
-      "resource_type_tesim": ["Research Paper"],
       "creator_tesim": ["McGrattan, Ellen R.",
                         "Prescott, Edward C."],
-      "publisher_tesim": ["Federal Reserve Bank of Minneapolis"],
-      "date_created_tesim": ["2005-09"],
-      "identifier_tesim": ["https://doi.org/10.21034/wp.636"],
-      "member_of_collections_ssim": ["New Working Papers",
-                                     "Working Papers"],
-      "title_ssi": "Expensed and Sweat Equity",
-      "date_created_ssi": "2005-09",
-      "human_readable_type_tesim": ["Publication"]
+      "date_created_tesim": ["2005-09"]
     }
   end
 
   describe '#chicago_citation' do
-    let(:citation) { presenter.chicago_citation }
     it 'includes the authors' do
       expect(citation).to include 'McGrattan, Ellen R., and Edward C. Prescott'
     end
@@ -44,25 +30,154 @@ RSpec.describe Cypripedium::CitationFormatter do
          "Carlstrom, Charles T., 1960-\n",      # birth date and non-printing character
          " \tAvenancio-León, Carlos",           # non-printing character with UTF8 chars that should be kept
          "Juster, F. Thomas (Francis Thomas), 1926-", # initial expansion and birth date should be dropped
-         "Cole, Harold Linh, 1957-2057"] # birth and death dates
-      expect(citation).to include 'Kocherlakota, Narayana Rao, Charles T. Carlstrom, Carlos Avenancio-León, F. Thomas Juster, and Harold Linh Cole'
+         "Wang, Ping, 1957 December 5-",        # verbose birth
+         "Cole, Harold Linh, 1957-2057"]        # birth and death dates
+      expect(citation).to include 'Kocherlakota, Narayana Rao, Charles T. Carlstrom, Carlos Avenancio-León, F. Thomas Juster, Ping Wang, and Harold Linh Cole'
     end
 
-    it 'includes the DOI' do
-      expect(citation).to include('doi')
-    end
-
-    it 'provides the direct repository link when no DOI is present' do
+    it 'provides the direct link if DOI does not exist' do
       solr_data.delete(:identifier_tesim)
       expect(citation).to include 'https://researchdatabase.minneapolisfed.org/concern/publications/br86b3634'
     end
 
-    it 'includes the Issue Number' do
-      expect(citation).to include('636')
+    describe 'for working papers' do
+      let(:solr_data) do
+        # Working paper, multiple authors, doi in identifier
+        {
+          "has_model_ssim": ["Publication"],
+          "id": "br86b3634",
+          "series_tesim": ["Working paper (Federal Reserve Bank of Minneapolis. Research Department)"],
+          "issue_number_tesim": ["636"],
+          "title_tesim": ["Expensed and Sweat Equity"],
+          "resource_type_tesim": ["Research Paper"],
+          "creator_tesim": ["McGrattan, Ellen R.",
+                            "Prescott, Edward C."],
+          "publisher_tesim": ["Federal Reserve Bank of Minneapolis"],
+          "date_created_tesim": ["2005-09"],
+          "identifier_tesim": ["https://doi.org/10.21034/wp.636"]
+        }
+      end
+
+      it 'includes the Issue Number' do
+        expect(citation).to include('636')
+      end
+
+      it 'includes the DOI' do
+        expect(citation).to include('doi')
+      end
+
+      it 'formats elements correctly' do
+        expect(citation).to eq 'McGrattan, Ellen R., and Edward C. Prescott. “Expensed and Sweat Equity.” Working Paper 636. Federal Reserve Bank of Minneapolis, 2005. https://doi.org/10.21034/wp.636.'
+      end
     end
 
-    it 'formats elements correctly' do
-      expect(citation).to eq 'McGrattan, Ellen R., and Edward C. Prescott. “Expensed and Sweat Equity.” Working Paper 636. Federal Reserve Bank of Minneapolis, Minneapolis, MN, 2005. https://doi.org/10.21034/wp.636.'
+    describe 'for journal articles' do
+      let(:solr_data) do
+        # Journal article, multiple authors, doi
+        {
+          "has_model_ssim": ["Publication"],
+          "id": "12579s459",
+          "series_tesim": ["Quarterly review (Federal Reserve Bank of Minneapolis. Research Department)"],
+          "issue_number_tesim": ["Vol. 16, No. 1"],
+          "title_tesim": ["Direct Investment: A Doubtful Alternative to International Debt"],
+          "resource_type_tesim": ["Article"],
+          "creator_tesim": ["English, William B. (William Berkeley), 1960-",
+                            "Cole, Harold Linh, 1957-"],
+          "publisher_tesim": ["Federal Reserve Bank of Minneapolis"],
+          "date_created_tesim": ["1992 Winter"],
+          "identifier_tesim": ["https://doi.org/10.21034/qr.1612"]
+        }
+      end
+
+      it 'italicizes the journal name' do
+        expect(citation).to include('<i>Quarterly Review</i>')
+      end
+
+      it 'includes the volume number' do
+        expect(citation).to include('16')
+      end
+
+      it 'includes the issue number' do
+        expect(citation).to include('no. 1')
+      end
+
+      it 'includes the date' do
+        expect(citation).to include('1992')
+      end
+
+      it 'formats elements correctly' do
+        expect(citation).to eq 'English, William B., and Harold Linh Cole. “Direct Investment: '\
+          'A Doubtful Alternative to International Debt.” <i>Quarterly Review</i> 16, no. 1 (1992). '\
+          'https://doi.org/10.21034/qr.1612.'
+      end
+    end
+
+    describe 'for conference proceedings' do
+      let(:solr_data) do
+        # Conference proceeding, multiple authors
+        {
+          "has_model_ssim": ["ConferenceProceeding"],
+          "id": "ks65hc256",
+          "series_tesim": ["International perspectives on debt, growth, and business cycles"],
+          "title_tesim": ["International Business Cycles"],
+          "resource_type_tesim": ["Conference Proceeding"],
+          "creator_tesim": ["Ickes, Barry William",
+                            "Ahmed, Shaghil, 1959-",
+                            "Yoo, Byung Sam, 1952-",
+                            "Wang, Ping, 1957 December 5-"],
+          "date_created_tesim": ["1989-07"]
+        }
+      end
+
+      it 'includes the conference name' do
+        expect(citation).to include('International Perspectives on Debt, Growth, and Business Cycles')
+      end
+
+      it 'includes the conference sponsor' do
+        expect(citation).to include('Federal Reserve Bank of Minneapolis')
+      end
+
+      it 'formats elements correctly' do
+        expect(citation).to eq 'Ickes, Barry William, Shaghil Ahmed, Byung Sam Yoo, and Ping Wang. '\
+            '“International Business Cycles.” Paper Presented at the International Perspectives on Debt, '\
+            'Growth, and Business Cycles Conference, Federal Reserve Bank of Minneapolis, Minneapolis, MN, 1989.'\
+            ' https://researchdatabase.minneapolisfed.org/concern/conference_proceedings/ks65hc256.'
+      end
+    end
+
+    describe 'for datasets' do
+      let(:solr_data) do
+        # Independent dataset
+        {
+          "has_model_ssim": ["Dataset"],
+          "id": "6969z0838",
+          "title_tesim": ["Railroad Stock Prices, 1834-1845."],
+          "date_uploaded_dtsi": "2018-04-03T15:57:49Z",
+          "resource_type_tesim": ["Dataset"],
+          "creator_tesim": ["Weber, Warren E."],
+          "publisher_tesim": ["Federal Reserve Bank of Minneapolis. Research Dept."]
+        }
+      end
+
+      it 'lists independent datasets as belonging to the "Research Database"' do
+        expect(citation).to include('Research Database')
+      end
+
+      it 'uses the upload date if no creation date is provided' do
+        expect(citation).to include('2018')
+      end
+
+      it 'identifies supporting data' do
+        solr_data["series_tesim"] = ["Staff report (Federal Reserve Bank of Minneapolis. Research Department)"]
+        solr_data["issue_number_tesim"] = ["396"]
+        expect(citation).to include('Supporting Data. Staff Report 396')
+      end
+
+      it 'formats elements correctly' do
+        expect(citation).to eq 'Weber, Warren E. “Railroad Stock Prices, 1834-1845.” Research Database. '\
+          'Federal Reserve Bank of Minneapolis. Research Dept., 2018. '\
+          'https://researchdatabase.minneapolisfed.org/concern/datasets/6969z0838.'
+      end
     end
   end
 


### PR DESCRIPTION
This commit adds support (and corresponding tests) to support displaying specific citation types based on the resource type of the object.

The currently supported resource to CSL type mappings are:
* `Article` --> `article-journal`
* `Conference Proceeding` --> `paper-conference`
* `Dataset` --> `dataset`
* `Other` --> `dataset`
* `Report` --> `article-journal`
* `Research Paper` --> `manuscript`
* `Software or Program Code` --> `dataset`
* _default_ --> `dataset`

The corresponding tests focus on Chicago reference list style.