### PR TITLE
Fix custom sort order on Collection pages

### DIFF
--- a/app/patches/extensions/collection_search_builder.rb
+++ b/app/patches/extensions/collection_search_builder.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Remove the CollectionSearchBuilder method override that forces all requests to sort by title
+# which causes the app to fallback to the base implementation in Blacklight::Solr::SearchBuilderBehavior
+module Extensions
+  module CollectionSearchBuilder
+    def self.included(k)
+      k.class_eval do
+        remove_method :add_sorting_to_solr
+      end
+    end
+  end
+end

--- a/config/initializers/patches.rb
+++ b/config/initializers/patches.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+ActiveSupport::Reloader.to_prepare do
+  # Extend engine and gem classes here, so this gets called on reload
+  # to re-patch the newly redefined classes
+  Hyrax::CollectionSearchBuilder.include(Extensions::CollectionSearchBuilder)
+end

--- a/spec/search_builders/hyrax/collection_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/collection_search_builder_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Hyrax::CollectionSearchBuilder do
+  subject(:builder) { described_class.new(scope) }
+  let(:scope) { Hyrax::CollectionsController.new }
+
+  describe '#add_sorting_to_solr' do
+    let(:builder) { described_class.new(scope).with(blacklight_params) }
+    let(:blacklight_params) do
+      { "sort" => "system_create_dtsi desc", "per_page" => "50", "locale" => "en" }.with_indifferent_access
+    end
+    let(:solr_parameters) { {} }
+
+    before { builder.add_sorting_to_solr(solr_parameters) }
+
+    it 'sets the solr paramters for sorting correctly' do
+      expect(solr_parameters[:sort]).to eq('system_create_dtsi desc')
+    end
+  end
+end


### PR DESCRIPTION
**ISSUE**
When a user selected a custom sort order on Collecion landing pages, member items would be always be shown in the same apparently random order regardless of the sort selection.

**DIAGNOSIS**
At some point, Hyrax added an override to the default sort order processor that attempted to sort by `title_si` when no specific query was provided.  The collection landing page uses a filter rather than a query to scope the member items, so the sort order was being set to `title_si asc`; however, there is no `title_si` index so the results were being returned in an apparently random order.

**SOLUTION**
Remove the Hyrax code attempting to sort by title so that the application falls back to the base search builder implementation which correctly includes any user specified sort order.

**BEFORE**
<img width="750" alt="image" src="https://github.com/curationexperts/cypripedium/assets/3064318/65b084a2-e3de-4008-8f6b-dd8334bd1150">


**AFTER**
<img width="731" alt="image" src="https://github.com/curationexperts/cypripedium/assets/3064318/23fea85d-83c8-49a4-ac95-2ef9249cd20a">
