### PR TITLE
Sort volume and issue numbers numerically instead of alphabetically

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -268,8 +268,8 @@ class CatalogController < ApplicationController
     # the default sort oder in app/models/search_builder.rb so that the contents
     # of a collection will sort by issue number if there is no query string present.
     config.add_sort_field "score desc, #{modified_field} desc", label: "relevance"
-    config.add_sort_field "issue_number_ssi desc", label: "issue number \u25BC"
-    config.add_sort_field "issue_number_ssi asc", label: "issue number \u25B2"
+    config.add_sort_field "volume_number_isi desc, issue_number_isi desc, system_create_dtsi desc", label: "issue number \u25BC"
+    config.add_sort_field "volume_number_isi asc, issue_number_isi asc, system_create_dtsi asc", label: "issue number \u25B2"
     config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
     config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"
     config.add_sort_field "title_ssi asc, score desc", label: "title \u25B2"

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -17,7 +17,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   # the sort order.
   def sort_by_issue_number_when_no_query(solr_parameters)
     return unless @blacklight_params[:controller] == "hyrax/collections"
-    issue_number_sort = "issue_number_ssi desc, system_modified_dtsi desc"
+    issue_number_sort = "volume_number_isi desc, issue_number_isi desc, system_create_dtsi desc"
     solr_parameters["sort"] = issue_number_sort if @blacklight_params[:q].nil? && @blacklight_params[:sort].nil?
   end
 


### PR DESCRIPTION
**ISSUE**
When a user sorted by issue number, the resulting lists were sorted in alphabetic rather than numeric order: e.g. we were getting this:
    ```
      "1"
      "10"
      "105"
      "2"
      "40"
      "5"
    ```
instead of this
    ```
       1
       2
       5
       10
       40
       105
    ```  

**SOLUTION**
Instead of sorting on the string field, parse the volume and issue numbers separately and index them numerically.

Once we have the values in separate indexes, we can sort on the numeric fields to get the desired search result order.

## BEFORE
<img width="979" alt="image" src="https://github.com/curationexperts/cypripedium/assets/3064318/59f1c70d-1765-432d-88de-21fd790fdcbf">

## AFTER
<img width="958" alt="image" src="https://github.com/curationexperts/cypripedium/assets/3064318/b65c1850-83b5-4623-9296-a5653ed06ae9">

