### PR TITLE
Fix SimpleForm custom input reload error in development environment

### DIFF
--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -176,7 +176,10 @@ end
 # see https://github.com/heartcombo/simple_form/blob/8f77f598b32ed11b0d56c44481607a6e911bcecb/lib/simple_form/form_builder.rb#L676
 # issue reported on https://github.com/heartcombo/simple_form/commit/ff3903fe9346199e39538a39ea4e5a5694e31541
 # Temporary work-around: explicitly reference class names for any custom input classes here:
-MultiValueInput
-ControlledVocabularyInput
-MultiValueSelectInput
-MultifileInput
+ActiveSupport::Reloader.to_prepare do
+  # Ensure custom inputs are loaded at startup and anytime code is reloaded
+  MultiValueInput
+  ControlledVocabularyInput
+  MultiValueSelectInput
+  MultifileInput
+end


### PR DESCRIPTION
**ISSUE**
SimpleForm custom inputs were not being reloaded in the development environment causing the local webserver to encounter an exception when attempting to display forms after code modification.

**FIX**
Add a reload callback to re-initilize the custom inputs on application startup and reloads in the development environment.