### PR TITLE
Refactor citation presenter to use volume and issue indexed in Solr

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -30,6 +30,17 @@ class SolrDocument
     self['alpha_creator_tesim']
   end
 
+  # Issue number as a scalar integer
+  # Note: the `issue_number` field holds both the volume and issue number concatenated as text
+  def issue_num
+    self['issue_number_isi']
+  end
+
+  # Volume number as a scalar integer
+  def volume_num
+    self['volume_number_isi']
+  end
+
   # Do content negotiation for AF models.
 
   use_extension(Hydra::ContentNegotiation)

--- a/app/presenters/cypripedium/citation_formatter.rb
+++ b/app/presenters/cypripedium/citation_formatter.rb
@@ -48,8 +48,8 @@ module Cypripedium
         type: citation_type,
         title: title&.first,
         author: creators_for_citation,
-        volume: volume_number_for_citation,
-        issue: issue_number_for_citation,
+        volume: volume_num,
+        issue: issue_num,
         URL: url,
         publisher: publisher&.first || 'Federal Reserve Bank of Minneapolis, Minneapolis, MN',
         # 'publisher-place': 'Minneapolis, MN',
@@ -68,7 +68,7 @@ module Cypripedium
           'publisher' => nil } # publisher is inlcuded in comma separated sponsor info in conference details instead
       when 'manuscript', 'dataset'
         { 'collection-title' => [dataset_label, series_for_citation].compact.join('. '),
-          'collection-number' => issue_number&.first }
+          'collection-number' => issue_num }
       else
         {} # always return a hash
       end
@@ -78,7 +78,7 @@ module Cypripedium
     def dataset_label
       return unless citation_type == 'dataset'
 
-      if issue_number || title.first&.match(/additional file/i)
+      if issue_num || title.first&.match(/additional file/i)
         'Supporting Data'
       else
         'Research Database'
@@ -142,30 +142,6 @@ module Cypripedium
     # Use the beginning of the series name up to the first parenthesis
     def series_for_citation
       series&.first&.split(' (')&.first
-    end
-
-    def issue_number_for_citation
-      parse_issue_and_volume[:issue]
-    end
-
-    def volume_number_for_citation
-      parse_issue_and_volume[:volume]
-    end
-
-    # extract alpha-numeric issue and volume number from issue field
-    # sample data can appear as
-    #   Vol. 16, No. 1
-    #   vol.10 no.36
-    #   no. 41
-    #   no.93
-    #   130
-    #   081
-    #   "vol.8 no.59 "
-    #   no. 54A
-    def parse_issue_and_volume
-      return { issue: nil, volume: nil } unless issue_number
-
-      @parse_issue_and_volume ||= issue_number.first.match(/^(v(ol)?\.?\s*(?<volume>\w+),?\s*)?(no\.?)?\s*(?<issue>\w+)/i)
     end
   end
 end

--- a/app/presenters/cypripedium_work_presenter.rb
+++ b/app/presenters/cypripedium_work_presenter.rb
@@ -5,6 +5,8 @@ class CypripediumWorkPresenter < Hyrax::WorkShowPresenter
 
   Attributes.to_a.each { |term| delegate term, to: :solr_document }
   delegate :alpha_creator, to: :solr_document
+  delegate :issue_num, to: :solr_document
+  delegate :volume_num, to: :solr_document
 
   def work_zip
     WorkZip.latest(id).first || WorkZip.new(work_id: id)

--- a/spec/presenters/cypripedium/citation_formatter_spec.rb
+++ b/spec/presenters/cypripedium/citation_formatter_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Cypripedium::CitationFormatter do
           "has_model_ssim": ["Publication"],
           "id": "br86b3634",
           "series_tesim": ["Working paper (Federal Reserve Bank of Minneapolis. Research Department)"],
-          "issue_number_tesim": ["636"],
+          "issue_number_isi": 636,
           "title_tesim": ["Expensed and Sweat Equity"],
           "resource_type_tesim": ["Research Paper"],
           "creator_tesim": ["McGrattan, Ellen R.",
@@ -102,7 +102,8 @@ RSpec.describe Cypripedium::CitationFormatter do
           "has_model_ssim": ["Publication"],
           "id": "12579s459",
           "series_tesim": ["Quarterly review (Federal Reserve Bank of Minneapolis. Research Department)"],
-          "issue_number_tesim": ["Vol. 16, No. 1"],
+          "volume_number_isi": 16,
+          "issue_number_isi": 1,
           "title_tesim": ["Direct Investment: A Doubtful Alternative to International Debt"],
           "resource_type_tesim": ["Article"],
           "creator_tesim": ["English, William B. (William Berkeley), 1960-",
@@ -189,7 +190,7 @@ RSpec.describe Cypripedium::CitationFormatter do
 
       it 'identifies supporting data' do
         solr_data["series_tesim"] = ["Staff report (Federal Reserve Bank of Minneapolis. Research Department)"]
-        solr_data["issue_number_tesim"] = ["396"]
+        solr_data["issue_number_isi"] = 396
         expect(citation).to include('Supporting Data. Staff Report 396')
       end
 


### PR DESCRIPTION
We now have separate index and volume numbers indexed into Solr, so we don't need to parse them out of the `issue_number` text field at runtime.