### PR TITLE
Fix issue number indexing bug

### DIFF
--- a/app/indexers/indexes_metadata.rb
+++ b/app/indexers/indexes_metadata.rb
@@ -55,14 +55,19 @@ module IndexesMetadata
 
   # Convert issue portion of `issue_number` to an Integer
   # returns nil for non-integer and nil values
+  # Note: force base 10 conversion to correctly handle leading 0's
+  # "060" --> 60 (base 10)
+  # instead of
+  # "060" --> 48 (base 8, octal)
   def issue_no
-    Integer(parsed_issue[:issue], exception: false)
+    Integer(parsed_issue[:issue], 10, exception: false)
   end
 
   # Convert volume portion of `issue_number` to an Integer
   # returns nil for non-integer and nil values
+  # Note: force base 10 conversion to correctly handle leading 0's
   def volume_no
-    Integer(parsed_issue[:volume], exception: false)
+    Integer(parsed_issue[:volume], 10, exception: false)
   end
 
   # Extract issue and volume numbers from the `issue_number` field

--- a/spec/indexers/cypripedium_indexer_spec.rb
+++ b/spec/indexers/cypripedium_indexer_spec.rb
@@ -104,6 +104,18 @@ RSpec.describe CypripediumIndexer, clean: true do
       it 'indexes issue as a sortable integer' do
         expect(solr_doc['issue_number_isi']).to eq 12
       end
+
+      # Ruby interprets a leading 0 indicates as an octal number by default
+      # see https://docs.ruby-lang.org/en/2.0.0/syntax/literals_rdoc.html#top
+      # This test ensures we handle that correctly, so
+      # "060" --> 60 (base 10)
+      # instead of
+      # "060" --> 48 (base 8, octal)
+      it 'ignores leading zeroes', :aggregate_failures do
+        attrs[:issue_number] = ["Vol. 010, No. 060"]
+        expect(solr_doc['volume_number_isi']).to eq 10
+        expect(solr_doc['issue_number_isi']).to eq 60
+      end
     end
   end
 


### PR DESCRIPTION
**BUG**
Items with issues numbers with leading zeroes are being indexed as octal numbers instead of decimal: e.g.
"060" --> 48 (base 8, octal)
indtead of
"060" --> 60 (base 10)

**DIAGNOSIS**
Rails interprets a leading 0 in numeric literals as an octal number. See: https://docs.ruby-lang.org/en/2.0.0/syntax/literals_rdoc.html#label-Numbers

**FIX**
Add a test and refactor the code to ensure we cast issue and volume strings to base-10 decimal integers.

**BEFORE (id, issue_number_ssi[string], issue_number_isi[numeric])**
<img width="964" alt="image" src="https://github.com/curationexperts/cypripedium/assets/3064318/58c8af61-53e9-4717-b886-e04bd2ea50fa">

**AFTER**
<img width="1072" alt="image" src="https://github.com/curationexperts/cypripedium/assets/3064318/27eb3336-9914-46d1-afff-eaccce634a46">

