### PR TITLE
Allow APA and MLA citations to be disabled or enabled

### DIFF
--- a/app/views/hyrax/citations/work.html.erb
+++ b/app/views/hyrax/citations/work.html.erb
@@ -16,15 +16,19 @@
     <%= @presenter.chicago_citation %>
   </div>
 
-  <div class="apa-citation">
-    <h4><%= t('blacklight.citation.apa') %></h4>
-    <%= @presenter.apa_citation %>
-  </div>
+  <% if Flipflop.apa_citation?%>
+    <div class="apa-citation">
+      <h4><%= t('blacklight.citation.apa') %></h4>
+      <%= @presenter.apa_citation %>
+    </div>
+  <% end %>
 
-  <div class="mla-citation">
-    <h4><%= t('blacklight.citation.mla') %></h4>
-    <%= @presenter.mla_citation %>
-  </div>
+  <% if Flipflop.mla_citation?%>
+    <div class="mla-citation">
+      <h4><%= t('blacklight.citation.mla') %></h4>
+      <%= @presenter.mla_citation %>
+    </div>
+  <% end %>
 </div>
 
 <div class="modal-footer">

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+Flipflop.configure do
+  feature :apa_citation,
+          default: false,
+          description: "Display APA format citation in the citation pop-up"
+  feature :mla_citation,
+          default: false,
+          description: "Display MLA format citation in the citation pop-up"
+end


### PR DESCRIPTION
This commit wraps the APA and MLA citation in a feature flipper so that administrators can enable or disable them ad-hoc in any desired environment.

These citation formats are disabled by default.

<img width="1094" alt="image" src="https://github.com/curationexperts/cypripedium/assets/3064318/6d4909fe-6f3d-4320-933f-51928efeea70">
