### PR TITLE
Address potential "tabnabbing" vulnerability

### DIFF
--- a/app/renderers/hyrax/renderers/license_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/license_attribute_renderer.rb
@@ -19,7 +19,7 @@ module Hyrax
         license_html = if parsed_uri.nil?
                          ERB::Util.h(value)
                        else
-                         %(<a href=#{ERB::Util.h(value)} target="_blank">#{Hyrax.config.license_service_class.new.label(value)}</a>)
+                         %(<a href=#{ERB::Util.h(value)}>#{Hyrax.config.license_service_class.new.label(value)}</a>)
                        end
         if microdata_value_attributes(field).present?
           "<span#{html_attributes(microdata_value_attributes(field))}>#{license_html}</span>"

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,8 +2,8 @@
   <div class="container-fluid">
     <div class="navbar-text text-left">
         <p><%= t('hyrax.footer.service_html') %></p>
-        <p><a class="navbar-link" target="_blank" href="https://minneapolisfed.org">Minneapolis Fed Home</a></p>
-        <p><a class="navbar-link" target="_blank" href="https://minneapolisfed.org/site-information/disclaimer">Disclaimer</a> | <a class="navbar-link" target="_blank" href="https://minneapolisfed.org/site-information/privacy-policies">Privacy Policy</a></p>
+        <p><a class="navbar-link" href="https://minneapolisfed.org">Minneapolis Fed Home</a></p>
+        <p><a class="navbar-link" href="https://minneapolisfed.org/site-information/disclaimer">Disclaimer</a> | <a class="navbar-link" href="https://minneapolisfed.org/site-information/privacy-policies">Privacy Policy</a></p>
     </div>
     <div class="navbar-right">
       <div class="navbar-text text-right">

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -53,7 +53,7 @@ de:
       suffix: "@ Example.org"
     footer:
       copyright_html: "<strong>Copyright &copy; 2018 Federal Reserve Bank of Minneapolis</strong>"
-      service_html: Ein Dienst von <a href="https://research.minneapolisfed.org" class="navbar-link" target="_blank">Federal Reserve Bank of Minneapolis Research Division</a>.
+      service_html: Ein Dienst von <a href="https://research.minneapolisfed.org" class="navbar-link">Federal Reserve Bank of Minneapolis Research Division</a>.
     institution_name: Federal Reserve Bank of Minneapolis
     institution_name_full: Federal Reserve Bank of Minneapolis Research Division
     product_name: Research Database

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -112,4 +112,4 @@ en:
       suffix:               "@example.org"
     footer:
       copyright_html: "<strong>Copyright &copy; 2022 Federal Reserve Bank of Minneapolis</strong>"
-      service_html: A service of the <a href="https://www.minneapolisfed.org/economic-research" class="navbar-link" target="_blank">Federal Reserve Bank of Minneapolis Research Division</a>.
+      service_html: A service of the <a href="https://www.minneapolisfed.org/economic-research" class="navbar-link">Federal Reserve Bank of Minneapolis Research Division</a>.

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -53,7 +53,7 @@ es:
       suffix: "@example.org"
     footer:
       copyright_html: "<strong>Copyright &copy; 2018  &copy; 2018 Federal Reserve Bank of Minneapolis</strong>"
-      service_html: Un servicio de <a href="https://research.minneapolisfed.org" class="navbar-link" target="_blank">Federal Reserve Bank of Minneapolis Research Division</a>.
+      service_html: Un servicio de <a href="https://research.minneapolisfed.org" class="navbar-link">Federal Reserve Bank of Minneapolis Research Division</a>.
     institution_name: Federal Reserve Bank of Minneapolis
     institution_name_full: Federal Reserve Bank of Minneapolis Research Division
     product_name: Research Database

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -53,7 +53,7 @@ fr:
       suffix: "@ Example.org"
     footer:
       copyright_html: "<strong>Copyright &copy; 2018 Federal Reserve Bank of Minneapolis/strong>"
-      service_html: Un service de <a href="https://research.minneapolisfed.org" class="navbar-link" target="_blank">Federal Reserve Bank of Minneapolis Research Division</a>.
+      service_html: Un service de <a href="https://research.minneapolisfed.org" class="navbar-link">Federal Reserve Bank of Minneapolis Research Division</a>.
     institution_name: Federal Reserve Bank of Minneapolis
     institution_name_full: Federal Reserve Bank of Minneapolis Research Division
     product_name: Research Database

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -53,7 +53,7 @@ it:
       suffix: "@ example.org"
     footer:
       copyright_html: "<strong>Copyright &copy; 2018 Federal Reserve Bank of Minneapolis</strong>"
-      service_html: Un servizio di <a href="https://research.minneapolisfed.org" class="navbar-link" target="_blank">Federal Reserve Bank of Minneapolis Research Division</a>.
+      service_html: Un servizio di <a href="https://research.minneapolisfed.org" class="navbar-link">Federal Reserve Bank of Minneapolis Research Division</a>.
     institution_name: Federal Reserve Bank of Minneapolis
     institution_name_full: Federal Reserve Bank of Minneapolis Research Division
     product_name: Research Database

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -53,7 +53,7 @@ pt-BR:
       suffix: "@ Example.org"
     footer:
       copyright_html: "<strong>Copyright © 2018 Federal Reserve Bank of Minneapolis</strong>"
-      service_html: Um serviço de <a href="https://research.minneapolisfed.org" class="navbar-link" target="_blank">Federal Reserve Bank of Minneapolis Research Division</a>.
+      service_html: Um serviço de <a href="https://research.minneapolisfed.org" class="navbar-link">Federal Reserve Bank of Minneapolis Research Division</a>.
     institution_name: Federal Reserve Bank of Minneapolis
     institution_name_full: Federal Resesrve Bank of Minneapolis Research Division
     product_name: Research Database

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -53,7 +53,7 @@ zh:
       suffix: "@example.org"
     footer:
       copyright_html: "<strong>版权所有 &copy; 2018 Federal Reserve Bank of Minneapolis</strong>"
-      service_html: 的服务<a href="https://research.minneapolisfed.org" class="navbar-link" target="_blank">Federal Reserve Bank of Minneapolis Research Division</a>.
+      service_html: 的服务<a href="https://research.minneapolisfed.org" class="navbar-link">Federal Reserve Bank of Minneapolis Research Division</a>.
     institution_name: Federal Reserve Bank of Minneapolis
     institution_name_full: Federal Reserve Bank of Minneapolis
     product_name: Research Database


### PR DESCRIPTION
**ISSUE**
FRB Security Scans have identified links to external sites opened in new windows (i.e. `target='_blank'`) as a potential security threat.

Examples of these links appear in the Research Database footer such as:
```
<a class="navbar-link" target="_blank" href="https://minneapolisfed.org">Minneapolis Fed Home</a>
<a class="navbar-link" target="_blank" href="https://minneapolisfed.org/site-information/disclaimer">Disclaimer</a>
<a class="navbar-link" target="_blank" href="https://minneapolisfed.org/site-information/privacy-policies">Privacy Policy</a>
<a href="https://www.minneapolisfed.org/economic-research" class="navbar-link" target="_blank">Federal Reserve Bank of Minneapolis Research Division</a>
```

For further details, see https://cwe.mitre.org/data/definitions/1022.html

**REOLUTION**
Although all of these links are to other trusted FRBM sites, modern accessibilty practices discourage opening content in new pages since this can create a disorenting experience for users not expecting to move to a new window (e.g. the browser back function no longer works as expected).

We've chosen to eliminate the new window targets and simply open the page in the same browser window because:
1. All modern browsers provide an easy mechanism that allows users to choose wether to open the link it the same window or a new window or tab, typically by using a modifier key when clicking the link.
2. The links in question are relatively low use footer links, and pose minimal disruption to workflow if opened in the current window.

**OTHER REFERENCES**
* https://theadminbar.com/accessibility-weekly/opening-links-in-new-tabs-or-not/
* https://www.w3.org/TR/WCAG21/#change-on-request