### PR TITLE
[FIX] Fix strscan gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem 'sassc-rails', '>= 2.1.0'
 gem 'sidekiq', '< 7'
 gem 'simple_form', ">= 5.0.0"
 gem 'solrizer'
+gem 'strscan', '1.0.3' # match version installed on server as system gem
 gem 'terser'
 gem 'turbolinks', '~> 5'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -956,7 +956,7 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
     ssrf_filter (1.0.8)
-    strscan (3.1.0)
+    strscan (1.0.3)
     sxp (1.2.4)
       matrix (~> 0.4)
       rdf (~> 3.2)
@@ -1094,6 +1094,7 @@ DEPENDENCIES
   simple_form (>= 5.0.0)
   solr_wrapper
   solrizer
+  strscan (= 1.0.3)
   terser
   turbolinks (~> 5)
   tzinfo-data


### PR DESCRIPTION
**ISSUE**
Previous gem update updated the version of the `strscan` gem. This gem is included on the server as a system gem which prevents bundler from loading a different version

**RESOLUTION**
Pin `strscan` to the version included in the current server build.