### PR TITLE
Set 'secure' attribute in cookies

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+Cypripedium::Application.config.session_store(
+  :cookie_store,
+  key: '_cypripedium_session',
+  secure: Rails.env.production?
+)


### PR DESCRIPTION
**ISSUE**
Security scanning software may flag the lack of the secure attribure in cookies; even when other architetural components ensure that cookies are only sent by the application when communicating over TLS encrypted HTTPS.

**RESOLUTION**
Ensure the attribute is set, even when sending over HTTPS