### PR TITLE
Reduce CircleCI parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             ruby_version: << parameters.ruby_version >>
             solr_version: 8.11.1
         working_directory: ~/project
-        parallelism: 4
+        parallelism: 2
         steps:
             - checkout
 


### PR DESCRIPTION
**RATIONALE**
The test suite is short enough that the overhead of running tests
in parallel may offset any speed benefit.
    
This change runs the full test suite in 2 parallel runs. Since the
overall speed difference is minimal, reducing the number of parallel
runs will reduce our overall credit usage.
    
**DURATION**
    ~3m 30s -> parallelism: 4
    ~4m 00s -> parallelism: 2
    ~5m 30s -> parallelism: 1
