### PR TITLE
[MAINTENANCE] Refactor TarBag to remove global variables

### DIFF
--- a/app/lib/hyrax/work_bag.rb
+++ b/app/lib/hyrax/work_bag.rb
@@ -4,7 +4,7 @@ require 'find'
 
 module Hyrax
   class WorkBag
-    attr_reader :bag_path, :bag, :work_id
+    attr_reader :bag_path, :bag, :work_id, :time_stamp
 
     # @param work_id [Array<String>]
     # @param time_stamp [String]

--- a/app/lib/hyrax/zip_bag.rb
+++ b/app/lib/hyrax/zip_bag.rb
@@ -3,12 +3,11 @@
 module Hyrax
   class ZipBag < WorkBag
     def compress
-      zip_name = "#{@bag_path}.zip"
-      src = @bag_path.to_s
+      zip_name = "#{bag_path}.zip"
 
       Zip::File.open(zip_name, Zip::File::CREATE) do |zip_file|
-        ::Find.find(*src) do |file|
-          relative_path = file.sub(@bag_path.to_s, "#{Rails.application.config.bag_prefix}_#{@time_stamp}")
+        ::Find.find(bag_path) do |file|
+          relative_path = file.sub(bag_path.to_s, "#{Rails.application.config.bag_prefix}_#{time_stamp}")
           zip_file.add(relative_path, File.new(file))
         end
       end


### PR DESCRIPTION
**ISSUE**
A number of instance variables were used to pass values across methods which made code linkages and dependencies difficult to analyze.

**RESOLUTION**
This change removes all instance variables in the class and passes required data as paramaters to the method calls. Where data from the instance initialization is required, we've replaced references to instance variables with corresponding attribute readers.

This change also adds more detailed testing of the TAR file that gets created to confirm it has the esxpected content.