### PR TITLE
[REFACTOR] Simplify TAR code and test

### DIFF
--- a/app/lib/hyrax/tar_bag.rb
+++ b/app/lib/hyrax/tar_bag.rb
@@ -24,13 +24,10 @@ module Hyrax
       end
     end
 
-    BLOCK_SIZE = 102_400_0
     def write_internal_file(tar, file)
-      tar.add_file relative_path(file), 0o755 do |tar_io|
-        File.open file, 'rb' do |rio|
-          while (buffer = rio.read(BLOCK_SIZE))
-            tar_io.write buffer
-          end
+      tar.add_file(relative_path(file), 0o755) do |dest_tar|
+        File.open file, 'rb' do |src_file|
+          IO.copy_stream(src_file, dest_tar)
         end
       end
     end

--- a/spec/lib/hyrax/tar_bag_spec.rb
+++ b/spec/lib/hyrax/tar_bag_spec.rb
@@ -6,7 +6,6 @@ require 'fileutils'
 RSpec.describe Hyrax::TarBag, type: :model do
   subject(:work_bag) { described_class.new(work_ids: [publication.id, publication2.id], time_stamp: time_stamp) }
   let(:time_stamp) { 109_092 }
-  let(:file_path) { Rails.application.config.bag_path }
 
   let(:pdf_file) do
     File.open(file_fixture('pdf-sample.pdf')) { |file| create(:file_set, content: file) }
@@ -24,42 +23,42 @@ RSpec.describe Hyrax::TarBag, type: :model do
     create(:publication, title: ['My Publication 2'], file_sets: [pdf_file, image_file])
   end
 
+  # Remove files created during the test
+  after do
+    FileUtils.rm_rf(Rails.application.config.bag_path)
+  end
+
   describe '#create' do
-    after do
-      FileUtils.rm_rf(file_path)
-    end
+    let(:expected_files) {
+      [
+        "mpls_fed_research_109092",
+        "mpls_fed_research_109092/bag-info.txt",
+        "mpls_fed_research_109092/bagit.txt",
+        "mpls_fed_research_109092/data",
+        %r{mpls_fed_research_109092/data/\w{9}},
+        %r{mpls_fed_research_109092/data/\w{9}/\w{9}\.xml},
+        %r{mpls_fed_research_109092/data/\w{9}/pdf-sample.pdf},
+        %r{mpls_fed_research_109092/data/\w{9}/sir_mordred.jpg},
+        "mpls_fed_research_109092/manifest-sha256.txt",
+        "mpls_fed_research_109092/tagmanifest-md5.txt",
+        "mpls_fed_research_109092/tagmanifest-sha1.txt"
+      ]
+    }
 
-    context 'a work file attached files' do
-      let(:expected_files) {
-        [
-          "mpls_fed_research_109092",
-          "mpls_fed_research_109092/bag-info.txt",
-          "mpls_fed_research_109092/bagit.txt",
-          "mpls_fed_research_109092/data",
-          %r{mpls_fed_research_109092/data/\w{9}},
-          %r{mpls_fed_research_109092/data/\w{9}/\w{9}\.xml},
-          %r{mpls_fed_research_109092/data/\w{9}/pdf-sample.pdf},
-          %r{mpls_fed_research_109092/data/\w{9}/sir_mordred.jpg},
-          "mpls_fed_research_109092/manifest-sha256.txt",
-          "mpls_fed_research_109092/tagmanifest-md5.txt",
-          "mpls_fed_research_109092/tagmanifest-sha1.txt"
-        ]
-      }
+    it 'writes works and metadata to a TAR file', :aggregate_failures do
+      work_bag.create
 
-      it 'creates a bag from the works', :aggregate_failures do
-        work_bag.create
-
-        # Get the entries in the tar bag
-        entries = []
-        File.open("#{work_bag.bag_path}.tar") do |io|
-          Gem::Package::TarReader.new(io) do |tar|
-            entries = tar.map(&:full_name)
-          end
+      expect(File.exist?("#{work_bag.bag_path}.tar"))
+      # Get the entries in the tar bag
+      entries = []
+      File.open("#{work_bag.bag_path}.tar") do |io|
+        Gem::Package::TarReader.new(io) do |tar|
+          entries = tar.map(&:full_name)
         end
-
-        expect(entries.length).to eq 15
-        expect(entries).to include(*expected_files)
       end
+
+      expect(entries.length).to eq 15
+      expect(entries).to include(*expected_files)
     end
   end
 end


### PR DESCRIPTION
Simplify TAR file generation by removing explicit block size during copy.

Remove unnecessary context levels from corresponding tests.