### PR TITLE
[REFACTOR] Clarify Collection sort order test

### DIFF
--- a/app/views/hyrax/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/collections/_show_document_list_row.html.erb
@@ -1,11 +1,11 @@
 <% id = document.id %>
-<tr id="document_<%= id %>">
+<tr class="document" id="document_<%= id %>">
   <td>&nbsp;
     <% if current_user and document.depositor != current_user.user_key %>
       <i class="glyphicon glyphicon-share-alt" />
     <% end %>
   </td>
-  <td>
+  <td class="title_author">
     <div class="media">
       <%= link_to [main_app, document], class: "media-left" do %>
         <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail", alt: "#{document.title_or_label} #{t('hyrax.homepage.admin_sets.thumbnail')}" }, { suppress_link: true } %>
@@ -18,9 +18,9 @@
       </div>
     </div>
   </td>
-  <td class="text-center"><%= document.issue_number.to_a.to_sentence %> </td>
-  <td class="text-center"><%= document.date_uploaded %> </td>
-  <td class="text-center"><%= document.date_modified %> </td>
+  <td class="text-center issue_number"><%= document.issue_number.to_a.to_sentence %> </td>
+  <td class="text-center uploaded"><%= document.date_uploaded %> </td>
+  <td class="text-center modified"><%= document.date_modified %> </td>
   <td class="text-center">
     <%= render_visibility_link(document) %>
   </td>


### PR DESCRIPTION
This change adds class names to the collection landing page results to allow us to write more expressive tests.

The tests are  updated to find all the documents in the collection and test all issue numbers.

The test for selecting a different sort order has also been enabled.