### PR TITLE
Fix for inconsistent locale/template error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,7 @@ class ApplicationController < ActionController::Base
   rescue_from I18n::InvalidLocale, with: :render_406
 
   def render_406
+    params.delete('locale')
     render file: Rails.root.join('app', 'views', 'static', 'not_acceptable.html.erb'), status: :not_acceptable, layout: true
   end
 end


### PR DESCRIPTION
**ISSUE**

In some randomized orders of the test suite, we get the following error:

```
Failures:

  1) Getting a friendly error for Invalid Locales visiting a locale that does not exist has a 406 page
     Failure/Error: <%= render_notifications(user: current_user) %>

     ActionView::Template::Error:
       "pluto" is not a valid locale

     # ./app/views/_user_util_links.html.erb:5:in `_app_views__user_util_links_html_erb__2932143581416229937_591080'
     # ./app/views/_masthead.html.erb:15:in `_app_views__masthead_html_erb__627904811801929399_591040'
     # ./app/controllers/application_controller.rb:21:in `render_406'
     # ./config/exception_middleware.rb:9:in `call'
     # ./spec/system/invalid_locale_spec.rb:13:in `block (3 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # I18n::InvalidLocale:
     #   "pluto" is not a valid locale
     #   ./config/exception_middleware.rb:9:in `call'

Finished in 1 minute 57.54 seconds (files took 8.56 seconds to load)
233 examples, 1 failure, 8 pending

Failed examples:

rspec ./spec/system/invalid_locale_spec.rb:12 # Getting a friendly error for Invalid Locales visiting a locale that does not exist has a 406 page

Randomized with seed 6472
```

**DIAGNOSIS**
If the application has not rendered a view using a vaild locale before encountering an invalid locale, it will still attempt to use the invalid locale when rendering partials in the layout.

**FIX**
Explicitly remove any invalid locale settings from the param list.