### PR TITLE
Separate creator names with semi-colons in index view

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -64,14 +64,17 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
     config.add_index_field solr_name("title_tesim", :stored_searchable), label: "Title", itemprop: 'name', if: false
-    config.add_index_field "alpha_creator_tesim", itemprop: 'creator', link_to_search: solr_name("creator", :facetable), label: "Creator"
-    config.add_index_field solr_name("series", :stored_searchable), link_to_search: solr_name("series", :facetable), label: "Series"
-    config.add_index_field solr_name("issue_number", :stored_searchable), label: "Number"
+    config.add_index_field solr_name("alpha_creator", :stored_searchable), itemprop: 'creator',
+                                                                           link_to_search: solr_name("creator", :facetable), label: "Creator",
+                                                                           separator_options: { words_connector: '; ', last_word_connector: '; and ' }
+    config.add_index_field solr_name("series", :stored_searchable), itemprop: 'series', link_to_search: solr_name("series", :facetable), label: "Series"
+    config.add_index_field solr_name("issue_number", :stored_searchable), label: "Number", itemprop: 'issue_number'
     config.add_index_field solr_name("date_created", :stored_sortable, type: :date), itemprop: 'dateCreated', helper_method: :human_readable_date
     config.add_index_field solr_name("abstract", :stored_searchable), itemprop: 'abstract', helper_method: :render_with_markdown
     config.add_index_field solr_name("description", :stored_searchable), itemprop: 'description', helper_method: :render_with_markdown
     config.add_index_field solr_name("keyword", :stored_searchable), itemprop: 'keywords', link_to_search: solr_name("keyword", :facetable)
     config.add_index_field solr_name("subject", :stored_searchable), itemprop: 'about', link_to_search: solr_name("subject", :facetable), label: "Subject (JEL)"
+
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
     config.add_show_field solr_name('title', :stored_searchable)

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -1,12 +1,9 @@
 <div class="col-sm-9">
   <table class="table">
     <% doc_presenter = index_presenter(document) %>
-    <% if document["submitting_type_tesim"] %>
-      <caption>About this <%= document["submitting_type_tesim"].first %></caption>
-    <% end %>
     <% index_fields(document).each do |field_name, field| -%>
       <% if should_render_index_field? document, field %>
-        <tr>
+        <tr class="<%= "attribute #{field.itemprop}" -%>">
           <th><span class="attribute-label h4"><%= render_index_field_label document, field: field_name %></span></th>
           <td><%= doc_presenter.field_value field %></td>
         </tr>

--- a/spec/views/catalog/_index_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_list_default.html.erb_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'catalog/_index_list_default.html.erb', type: :view do
+  before do
+    # Stub methods required by view that are typically provided by the CatalogController
+    without_partial_double_verification do
+      allow(view).to receive(:blacklight_config).and_return(CatalogController.blacklight_config)
+      allow(view).to receive(:blacklight_configuration_context).and_return(Blacklight::Configuration::Context.new(controller))
+      allow(view).to receive(:search_state).and_return(CatalogController.search_state_class.new(params, view.blacklight_config, controller))
+      allow(view).to receive(:search_action_path).and_return('http://example.com/catalog/[facet_search]/')
+    end
+  end
+
+  let(:document) {
+    SolrDocument.new(alpha_creator_tesim: ['author, first', 'Creator, Second', 'Originator, Third'])
+  }
+
+  it 'separates creators with semicolons' do
+    render 'catalog/index_list_default', document: document
+    expect(rendered).to have_selector('tr.creator td',
+                                      exact_text: 'author, first; Creator, Second; and Originator, Third')
+  end
+end


### PR DESCRIPTION
**BEFORE**
```
Boot, Arnoud W. A. (Willem Alexander), 1960-, Reinhart, Carmen M., and Tolstoy, Leo
                                            ^                    ^
```

**AFTER**
```
Boot, Arnoud W. A. (Willem Alexander), 1960-; Reinhart, Carmen M.; and Tolstoy, Leo
                                            ^                    ^
```