### PR TITLE
Display creators in alphbetical order on collection index pages

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -27,7 +27,7 @@ class SolrDocument
   end
 
   def alpha_creator
-    self['alpha_creator_tesim']
+    Array(self['alpha_creator_tesim'])
   end
 
   # Issue number as a scalar integer

--- a/app/views/hyrax/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/collections/_show_document_list_row.html.erb
@@ -1,10 +1,5 @@
 <% id = document.id %>
 <tr class="document" id="document_<%= id %>">
-  <td>&nbsp;
-    <% if current_user and document.depositor != current_user.user_key %>
-      <i class="glyphicon glyphicon-share-alt" />
-    <% end %>
-  </td>
   <td class="title_author">
     <div class="media">
       <%= link_to [main_app, document], class: "media-left" do %>
@@ -14,7 +9,9 @@
         <p class="media-heading">
           <strong><%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %></strong>
         </p>
-        <p><%= document.creator.to_sentence %></p>
+        <p class="alpha_creator">
+          <%= document.alpha_creator.to_sentence(words_connector: '; ', last_word_connector: '; and ') %>
+        </p>
       </div>
     </div>
   </td>

--- a/spec/views/hyrax/collections/_show_doucment_list_row.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_show_doucment_list_row.html.erb_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'hyrax/collections/_show_document_list_row.html.erb', type: :view do
+  before do
+    # Stub methods required by view that are typically provided by the CatalogController
+    without_partial_double_verification do
+      allow(view).to receive(:blacklight_config).and_return(CatalogController.blacklight_config)
+      allow(view).to receive(:blacklight_configuration_context).and_return(Blacklight::Configuration::Context.new(controller))
+      allow(view).to receive(:search_state).and_return(CatalogController.search_state_class.new(params, view.blacklight_config, controller))
+      allow(view).to receive(:search_action_path).and_return('http://example.com/catalog/[facet_search]/')
+    end
+  end
+
+  let(:document) {
+    SolrDocument.new(id: 'dummy_id', has_model_ssim: ["Publication"], alpha_creator_tesim: ['author, first', 'Creator, Second', 'Originator, Third'])
+  }
+
+  it 'separates creators with semicolons' do
+    render 'hyrax/collections/show_document_list_row', document: document
+    expect(rendered).to have_selector('#document_dummy_id p.alpha_creator',
+                                      text: 'author, first; Creator, Second; and Originator, Third')
+  end
+end


### PR DESCRIPTION
On collection landing pages,
* Sort creators alphabetically for each work
* Separate creator names with a semi-colon (instead of comma)
* Eliminate duplicated (alternate) names from creator listings
* Remove the "owned by someone else" icon next to other users' documents

**BEFORE**
<img width="740" alt="image" src="https://github.com/user-attachments/assets/11499ca6-651c-4d03-a095-292669e2fcee">


**AFTER**
<img width="669" alt="image" src="https://github.com/user-attachments/assets/f7ca6f41-8abd-44cf-8c43-0e3058ec7713">
