### PR TITLE
Fix collection listing heading

### DIFF
--- a/app/views/hyrax/collections/_show_document_list.html.erb
+++ b/app/views/hyrax/collections/_show_document_list.html.erb
@@ -3,7 +3,6 @@
 <caption class="sr-only"><%= t('hyrax.dashboard.my.heading.caption') %></caption>
 <thead>
 <tr>
-  <th>&nbsp;</th>
   <th><%= t("hyrax.dashboard.my.heading.title") %></th>
   <th class="text-center"><%= t("hyrax.dashboard.my.heading.issue_number") %></th>
   <th class="text-center"><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>


### PR DESCRIPTION
**ISSUE**
The column titles no longer aligned with the column data on collection landing pages.

**RESOLUTION**
Remove the blank header column corresponding to the shared-icon data column removed in Pull Request #613

**BEFORE***
<img width="1116" alt="image" src="https://github.com/user-attachments/assets/c9355a86-01b1-492c-99ae-f9e7c5f79d78">

**AFTER***
<img width="1211" alt="image" src="https://github.com/user-attachments/assets/1d4f3e0f-e4c4-4027-837d-36997ced3aeb">
