### PR TITLE
Remove dead_code and add coverage for CatalogController

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -7,10 +7,6 @@ class CatalogController < ApplicationController
   # This filter applies the hydra access controls
   before_action :enforce_show_permissions, only: :show
 
-  def self.uploaded_field
-    solr_name('system_create', :stored_sortable, type: :date)
-  end
-
   def self.modified_field
     solr_name('system_modified', :stored_sortable, type: :date)
   end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CatalogController do
+  let(:controller) { described_class.new }
+  # ensure we turn off bookmark controls in all views, e.g. blacklight gallery
+  # see https://github.com/projectblacklight/blacklight/blob/v6.25.0/app/controllers/concerns/blacklight/default_component_configuration.rb#L7
+  it 'disables bookmark controls' do
+    expect(controller.render_bookmarks_control?).to be_falsey
+  end
+end


### PR DESCRIPTION
**RATIONALE**
The code being removed is legacy template code from Sufia. The test ensures a setting necessary for the Blacklight Gallery gem is congiured.