### PR TITLE
Handle AdminSet deprecation

### DIFF
--- a/spec/system/bag_notification_spec.rb
+++ b/spec/system/bag_notification_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Recieve a notfication when creating a bag', type: :system, js: t
     end
 
     before do
-      AdminSet.find_or_create_default_admin_set_id
+      Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id
       Hyrax::CollectionType.find_or_create_default_collection_type
       publication
       publication2


### PR DESCRIPTION
**WARNING**
>DEPRECATION WARNING: '#find_or_create_default_admin_set_id' will be removed in Hyrax 4.0.  Instead, use 'Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id'. (called from block (3 levels) in <top (required)> at /Users/mark/_no_backup_/Projects/cypripedium/spec/system/bag_notification_spec.rb:29)

**RESOLUTION**
Use preferred class method call.