### PR TITLE
[FIX] Display full deprecation messages

### DIFF
--- a/app/patches/extensions/deprecation_reporting.rb
+++ b/app/patches/extensions/deprecation_reporting.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Override #warn method to handle different API expectations
+# i.e. old Deprecation gem API or ActiveSupport::Deprecation API
+# Signatures:
+#   def warn(context, message = nil, callstack = nil) - cbeer/deprecation gem
+#   def warn(context, message = nil, callstack = nil) - ActiveSupport::Deprecation
+#
+module Extensions
+  module DeprecationReporting
+    def self.included(k)
+      k.class_eval do
+        def self.warn(*args)
+          if args[0].is_a?(String)
+            message, callstack = args[0..1]
+          else
+            context, message, callstack = args[0..2]
+          end
+
+          return if context.respond_to?(:silenced?) && context.silenced?
+
+          if callstack.nil?
+            callstack = caller
+            callstack.shift
+          end
+
+          deprecation_message(callstack, message).tap do |m|
+            deprecation_behavior(context).each { |b| b.call(m, sanitized_callstack(callstack)) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/patches.rb
+++ b/config/initializers/patches.rb
@@ -5,4 +5,5 @@ ActiveSupport::Reloader.to_prepare do
   # to re-patch the newly redefined classes
   Hyrax::CollectionSearchBuilder.include(Extensions::CollectionSearchBuilder)
   Hydra::FileCharacterization::Characterizers::Fits.include(Extensions::ServletCharacterizer)
+  Deprecation.include(Extensions::DeprecationReporting)
 end


### PR DESCRIPTION
**ISSUE**
We are not getting details of the deprecation warnings.

The cbeer/deprecation gem uses an old calling signature
for warnings, but Hyrax and related code expect to use the calling
signature in ActiveSupport::Deprecation. So, the warn method
was reading the message as the context and setting the message to
nil, giving a very generic message.

**FIX**
Check to see whether the first argument being passed is a string,
which means the call is using the two-parameter calling signature,
or a class or other object, which means the call is using the
three-parameter calling signature.

**BEFORE**
>DEPRECATION WARNING: You are using deprecated behavior which will be removed from the next major or minor release. (called from block in <top (required)> at /Users/mark/_no_backup_/Projects/cypripedium/config/initializers/hyrax.rb:47) (1 times); e.g.:
>
>DEPRECATION WARNING: You are using deprecated behavior which will be removed from the next major or minor release. (called from new at /Users/mark/_no_backup_/Projects/cypripedium/app/lib/rdf_xml_service.rb:9) (2 times); e.g.:

**AFTER**
>DEPRECATION WARNING: google_analytics_id is deprecated; use analytics_id from config/analytics.yml instead. (called from block in <top (required)> at /Users/mark/_no_backup_/Projects/cypripedium/config/initializers/hyrax.rb:47) (1 times); e.g.:
>
>DEPRECATION WARNING: passing `request` is deprecated; pass a host as `hostname:` instead. (called from new at /Users/mark/_no_backup_/Projects/cypripedium/app/lib/rdf_xml_service.rb:9) (2 times); e.g.:
