### PR TITLE
Handle Google Analytics configuration deprecation

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -44,7 +44,7 @@ Hyrax.config do |config|
   config.analytics = false
 
   # Google Analytics tracking ID to gather usage statistics
-  config.google_analytics_id = 'UA-131289387-1'
+  # config.google_analytics_id = 'UA-131289387-1'
 
   # Date you wish to start collecting Google Analytic statistics for
   # Leaving it blank will set the start date to when ever the file was uploaded by


### PR DESCRIPTION
**MESSAGE**
>DEPRECATION WARNING: google_analytics_id is deprecated; use analytics_id from config/analytics.yml instead. (called from block in <top (required)> at /Users/mark/_no_backup_/Projects/cypripedium/config/initializers/hyrax.rb:48)

**RESOLTUTION**
The current key is for Google Universal Analytics, which Google [decomissioned on July 1, 2024](https://support.google.com/analytics/answer/11583528?hl=en). Since the key is no longer valid, we are commenting it out in the initializer to address the deprecation warning. There is no current GA4 tag for the application at this time.