### PR TITLE
Ignore Node & Yarn working files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,10 @@ coverage
 dump.rdb
 vendor
 public/assets
+
+/public/packs
+/public/packs-test
+/node_modules
+/yarn-error.log
+yarn-debug.log*
+.yarn-integrity


### PR DESCRIPTION
This commit updates the `.gitignore` file to prevent Node and Yarn working files from being committed to the code repository.