### PR TITLE
Remove depencency on ActiveJobStatus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ git_source(:github) do |repo_name|
 end
 
 gem "actionview", ">= 5.1.6.2"
-gem 'active_job_status', '~> 1.2.1'
 gem 'bagit'
 gem 'bcrypt_pbkdf', '~> 1.1' # Needed to support more secure ssh keys
 gem 'bixby', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,9 +42,6 @@ GEM
     active_encode (0.8.2)
       rails
       sprockets (< 4)
-    active_job_status (1.2.1)
-      activejob (> 4.2)
-      activesupport (> 4.2)
     activejob (5.2.8.1)
       activesupport (= 5.2.8.1)
       globalid (>= 0.3.6)
@@ -1030,7 +1027,6 @@ PLATFORMS
 
 DEPENDENCIES
   actionview (>= 5.1.6.2)
-  active_job_status (~> 1.2.1)
   bagit
   bcrypt_pbkdf (~> 1.1)
   bixby (~> 3.0)

--- a/app/controllers/work_zips_controller.rb
+++ b/app/controllers/work_zips_controller.rb
@@ -9,8 +9,8 @@ class WorkZipsController < ApplicationController
   end
 
   def create
-    @work_zip = WorkZip.create!(work_id: params[:work_id])
-    @work_zip.job_id = BuildWorkZipJob.perform_later(@work_zip.id).job_id
+    @work_zip = WorkZip.create!(work_id: params[:work_id], status: :queued)
+    @work_zip.job_id = BuildWorkZipJob.perform_later(@work_zip).job_id
     @work_zip.save!
     redirect_back(fallback_location: root_path, notice: "A job has been queued to build the zip file. Please check back in a few minutes.")
   end

--- a/app/helpers/work_zips_helper.rb
+++ b/app/helpers/work_zips_helper.rb
@@ -4,10 +4,8 @@ module WorkZipsHelper
   def display_work_zip_controls(work_zip)
     if work_zip.file_path && File.exist?(work_zip.file_path)
       link_to 'Download the zip file', main_app.download_zip_path(work_zip.work_id), download: true
-    elsif work_zip.status == :unavailable
-      button_to 'Create the Zip', main_app.create_zip_path(work_zip.work_id)
-    elsif work_zip.status != :completed
-      tag.p("The job is not finished yet.  Please check back in a few minutes.  Current job status: #{work_zip.status}")
+    elsif work_zip.queued? || work_zip.working?
+      tag.p("The job is currently #{work_zip.status}. Please check back in a few minutes.")
     else
       button_to 'Create the Zip', main_app.create_zip_path(work_zip.work_id)
     end

--- a/app/jobs/build_work_zip_job.rb
+++ b/app/jobs/build_work_zip_job.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
-class BuildWorkZipJob < ActiveJobStatus::TrackableJob
+class BuildWorkZipJob < ApplicationJob
   queue_as :default
 
   # Find the WorkZip record and tell it to build a
   # zip file for its associated work.
   #
   # @param work_zip_id [String] The ID for the WorkZip record.
-  def perform(work_zip_id)
-    work_zip = WorkZip.find(work_zip_id)
+  def perform(work_zip)
     work_zip.create_zip
   end
 end

--- a/app/views/bag/_error_notification.html.erb
+++ b/app/views/bag/_error_notification.html.erb
@@ -1,4 +1,0 @@
-There was an error starting your bag job:
-<pre>
-<%= error %>
-</pre>

--- a/app/views/bag/_notification.html.erb
+++ b/app/views/bag/_notification.html.erb
@@ -1,3 +1,0 @@
-<div>
-  Your bag containing <%= work_count %> <%= 'work'.pluralize(work_count) %>, including <%= bag_files.first %>, is available for download at <a data-turbolinks='false' href='/bag/<%= bag_file_name %>.<%= bag_file_format %>'><%= bag_file_name %>.<%= bag_file_format %></a>
-</div>

--- a/config/initializers/active_job_status.rb
+++ b/config/initializers/active_job_status.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-ActiveJobStatus.store = ActiveSupport::Cache::RedisStore.new

--- a/db/migrate/20250109225453_add_status_to_work_zip.rb
+++ b/db/migrate/20250109225453_add_status_to_work_zip.rb
@@ -1,0 +1,5 @@
+class AddStatusToWorkZip < ActiveRecord::Migration[5.2]
+  def change
+    add_column :work_zips, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_17_203355) do
+ActiveRecord::Schema.define(version: 2025_01_09_225453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -589,6 +589,7 @@ ActiveRecord::Schema.define(version: 2024_01_17_203355) do
     t.string "file_path"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
   end
 
   add_foreign_key "collection_type_participants", "hyrax_collection_types"

--- a/spec/helpers/work_zips_helper_spec.rb
+++ b/spec/helpers/work_zips_helper_spec.rb
@@ -27,11 +27,7 @@ RSpec.describe WorkZipsHelper, type: :helper do
     end
 
     context 'when the job status is unavailable' do
-      let(:work_zip) { WorkZip.new(work_id: '123') }
-
-      before do
-        allow(work_zip).to receive(:status).and_return(:unavailable)
-      end
+      let(:work_zip) { WorkZip.new(work_id: '123', status: :unavailable) }
 
       it 'returns a button to create the zip file' do
         expect(return_value).to match(/\/zip\/123/)
@@ -39,15 +35,19 @@ RSpec.describe WorkZipsHelper, type: :helper do
       end
     end
 
-    context 'when the job is not yet complete' do
-      let(:work_zip) { WorkZip.new(work_id: '123') }
+    context 'when the job queued' do
+      let(:work_zip) { WorkZip.new(work_id: '123', status: :queued) }
 
-      before do
-        allow(work_zip).to receive(:status).and_return(:queued)
+      it 'returns a corresponding message' do
+        expect(return_value).to match(/job is currently queued. Please check back/)
       end
+    end
 
-      it 'returns a message that the zip file is still building' do
-        expect(return_value).to match(/not finished yet.  Please check back.*queued/)
+    context 'when the job working' do
+      let(:work_zip) { WorkZip.new(work_id: '123', status: :working) }
+
+      it 'returns a corresponding message' do
+        expect(return_value).to match(/job is currently working. Please check back/)
       end
     end
   end

--- a/spec/jobs/build_work_zip_job_spec.rb
+++ b/spec/jobs/build_work_zip_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe BuildWorkZipJob, type: :job do
     it 'calls the method to create the zip file' do
       allow(WorkZip).to receive(:find).with(work_zip.id).and_return(work_zip)
       expect(work_zip).to receive(:create_zip)
-      described_class.perform_now(work_zip.id)
+      described_class.perform_now(work_zip)
     end
   end
 end


### PR DESCRIPTION
**RATIONALE**
The active_job_status gem is no longer being maintained. The [last release](https://rubygems.org/gems/active_job_status) was in November 2016.

**RESOLUTION**
Use ActiveRecord enumberables to provide equivalent functionality.

**RELATED CHANGES**
This commit also
* Simplifies error notification code
* Simplifies job setup by using [GlobalID](https://guides.rubyonrails.org/active_job_basics.html#globalid) parameters for BuildWorkZipJob