### PR TITLE
Update XRay-Rails gem for Ruby 3.x compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1017,7 +1017,7 @@ GEM
       rexml
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    xray-rails (0.3.2)
+    xray-rails (0.3.3)
       rails (>= 3.1.0)
     yard (0.9.25)
     zeitwerk (2.6.12)


### PR DESCRIPTION
This commit updates the xray-rails gem and associated dependencies in anticipation of the upcomming Ruby 3.2 upgrade.