### PR TITLE
Refactor factories to handle creators more effectively

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ end
 group :test do
   gem 'database_cleaner'
   gem 'factory_bot'
+  gem 'faker'
   gem 'poltergeist'
   gem 'rspec-rails'
   gem 'rspec_junit_formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,6 +319,8 @@ GEM
     execjs (2.9.1)
     factory_bot (6.0.2)
       activesupport (>= 5.0.0)
+    faker (2.23.0)
+      i18n (>= 1.8.11, < 2)
     faraday (0.17.6)
       multipart-post (>= 1.2, < 3)
     faraday-encoding (0.0.5)
@@ -1050,6 +1052,7 @@ DEPENDENCIES
   dotenv-rails
   ed25519 (~> 1.2, >= 1.2.4)
   factory_bot
+  faker
   fcrepo_wrapper
   honeybadger (~> 4.4.0)
   hydra-file_characterization (~> 1.1)

--- a/spec/factories/creators.rb
+++ b/spec/factories/creators.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :creator do
-    display_name { 'Alvarez, Fernando, 1964-' }
+    display_name { "#{Faker::Name.last_name}, #{Faker::Name.first_name} #{Faker::Name.middle_name}" }
   end
 end

--- a/spec/factories/dataset.rb
+++ b/spec/factories/dataset.rb
@@ -3,28 +3,25 @@
 FactoryBot.define do
   factory :dataset do
     title { ['Testing'] }
+
     factory :dataset_without_description do
+      transient do
+        creators { create_list(:creator, 2) }
+      end
       title { ["The 1929 Stock Market: Irving Fisher Was Right: Additional Files"] }
-      creator { ["McGrattan, Ellen R.", "Prescott, Edward C."] }
-      creator_id { ['1', '2'] }
+      creator { creators.map(&:display_name) }
+      creator_id { creators.map(&:id) }
       series { ["Staff Report (Federal Reserve Bank of Minneapolis. Research Department)"] }
       resource_type { ["Dataset"] }
       visibility { "open" }
       abstract { ["This is my abstract"] }
       identifier { ["https://doi.org/10.21034/sr.600"] }
       related_url { ["Data supports Staff Report 315, \"Does Neoclassical Theory Account for the Effects of Big Fiscal Shocks? Evidence From World War II.\" https://doi.org/10.21034/sr.315"] }
-    end
-    factory :populated_dataset do
-      title { ["The 1929 Stock Market: Irving Fisher Was Right: Additional Files"] }
-      creator { ["McGrattan, Ellen R.", "Prescott, Edward C."] }
-      creator_id { ['1', '2'] }
-      series { ["Staff Report (Federal Reserve Bank of Minneapolis. Research Department)"] }
-      resource_type { ["Dataset"] }
-      visibility { "open" }
-      abstract { ["This is my abstract"] }
-      identifier { ["https://doi.org/10.21034/sr.600"] }
-      description { ["This is my description"] }
-      license { ["https://creativecommons.org/licenses/by-nc/4.0/"] }
+
+      factory :populated_dataset do
+        description { ["This is my description"] }
+        license { ["https://creativecommons.org/licenses/by-nc/4.0/"] }
+      end
     end
   end
 end

--- a/spec/factories/publication.rb
+++ b/spec/factories/publication.rb
@@ -4,9 +4,12 @@ FactoryBot.define do
   factory :publication do
     title { ["Testing"] }
     factory :populated_publication do
+      transient do
+        creators { create_list(:creator, 2) }
+      end
       title { ["The 1929 Stock Market: Irving Fisher Was Right: Additional Files"] }
-      creator { ["McGrattan, Ellen R.", "Prescott, Edward C."] }
-      creator_id { ['1', '2'] }
+      creator { creators.map(&:display_name) }
+      creator_id { creators.map(&:id) }
       series { ["Staff Report (Federal Reserve Bank of Minneapolis. Research Department)"] }
       resource_type { ["Dataset"] }
       visibility { "open" }

--- a/spec/jobs/creator_reindex_job_spec.rb
+++ b/spec/jobs/creator_reindex_job_spec.rb
@@ -3,32 +3,45 @@
 require 'rails_helper'
 
 RSpec.describe CreatorReindexJob, type: :job do
-  let(:publication) { FactoryBot.create(:populated_publication) }
-  let(:creator1) { Creator.create(display_name: publication['creator'].first) }
-
   context 'running the job' do
     it 'calls the method to reindex the associated works' do
-      allow(Creator).to receive(:find).with(creator1.id).and_return(creator1)
-      expect(creator1).to receive(:reindex_associated_works)
-      described_class.perform_now(creator1.id)
+      creator = FactoryBot.create(:creator)
+      allow(Creator).to receive(:find).with(creator.id).and_return(creator)
+      allow(creator).to receive(:reindex_associated_works)
+      described_class.perform_now(creator.id)
+      expect(creator).to have_received(:reindex_associated_works)
     end
   end
-  context "describe updating a hyrax work after a creator has been edited", clean: true do
-    let(:work) { FactoryBot.build(:populated_publication) }
+
+  context "editing a creator name", :clean, :aggregate_failures do
     let(:solr) { Blacklight.default_index.connection }
-    it "reindexes on save" do
-      creator1 = Creator.create(id: 1, display_name: "McGrattan, Ellen R.")
-      Creator.create(id: 2, display_name: "Prescott, Edward C.")
-      work.save!
+    let(:ellen_mcgrattan) { FactoryBot.create(:creator, display_name: 'McGrattan, Ellen R.') }
+
+    before do
+      @old_queue_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :test
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+    end
+
+    after do
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = false
+      ActiveJob::Base.queue_adapter = @old_queue_adapter
+    end
+
+    it "reindexes associated works" do
+      FactoryBot.create(:populated_publication, creators: [ellen_mcgrattan])
       response = solr.get 'select', params: { q: 'has_model_ssim:Publication' }
-      expect(response['response']['docs'].first['creator_tesim']).to include "McGrattan, Ellen R."
-      creator1.display_name = "Name, Some New"
-      expect(creator1).to receive(:reindex_setup)
-      creator1.save
-      described_class.perform_now(creator1.id)
+      expect(response['response']['docs'].first['creator_tesim']).to include 'McGrattan, Ellen R.'
+      expect(response['response']['docs'].first['creator_tesim']).not_to include 'Some New Name'
+
+      ellen_mcgrattan.display_name = 'Some New Name'
+      expect do
+        ellen_mcgrattan.save!
+      end.to have_performed_job(described_class)
+
       response = solr.get 'select', params: { q: 'has_model_ssim:Publication' }
-      expect(response['response']['docs'].first['creator_tesim']).to include "Name, Some New"
-      expect(response['response']['docs'].first['creator_tesim']).not_to include "McGrattan, Ellen R."
+      expect(response['response']['docs'].first['creator_tesim']).to include 'Some New Name'
+      expect(response['response']['docs'].first['creator_tesim']).not_to include 'McGrattan, Ellen R.'
     end
   end
 end

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -3,18 +3,18 @@ require 'rails_helper'
 
 RSpec.describe Publication, clean: true do
   let(:work) { FactoryBot.build(:publication) }
-  let(:creator) { FactoryBot.create(:creator, id: 1234) }
-  let(:creator_id) { creator.id }
+  let(:creator) { FactoryBot.create(:creator, display_name: 'Alvarez, Fernando, 1964-') }
 
   it_behaves_like 'a work with additional metadata'
+
   it "can set and retrieve a creator value" do
     publication = described_class.new
     publication.title = ["Some title, cuz it's required"]
     publication.creator = [creator.display_name]
-    publication.creator_id = [creator_id]
+    publication.creator_id = [creator.id]
     publication.save!
     expect(publication.creator).to eq(["Alvarez, Fernando, 1964-"])
-    expect(publication.creator_id).to eq([creator_id])
+    expect(publication.creator_id).to eq([creator.id])
     expect(publication.creator).to be_an_instance_of ActiveTriples::Relation
   end
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -2,11 +2,6 @@
 
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
-end
-
-# RSpec without Rails
-RSpec.configure do |config|
-  config.include FactoryBot::Syntax::Methods
 
   config.before(:suite) do
     FactoryBot.find_definitions

--- a/spec/system/google_structured_data_spec.rb
+++ b/spec/system/google_structured_data_spec.rb
@@ -3,46 +3,42 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.describe 'Use structured data that Google can parse', type: :system, clean: true, js: true do
-  let(:creator_one) { FactoryBot.create(:creator, display_name: 'McGrattan, Ellen R.', id: 1) }
-  let(:creator_two) { FactoryBot.create(:creator, display_name: 'Prescott, Edward C.', id: 2) }
+  let(:creator_one) { FactoryBot.create(:creator, display_name: 'McGrattan, Ellen R.') }
+  let(:creator_two) { FactoryBot.create(:creator, display_name: 'Prescott, Edward C.') }
+  let(:work) { FactoryBot.create(:populated_dataset, creators: [creator_one, creator_two]) }
+
   context "datasets" do
-    let(:work) { FactoryBot.create(:populated_dataset) }
     it "marks up with schema.org tags", :aggregate_failures do
-      creator_one
-      creator_two
       visit "/concern/datasets/#{work.id}"
       creators = page.all(:css, "[itemprop='creator']")
       expect(creators.first.text).to eq "McGrattan, Ellen R."
       expect(creators.last.text).to eq "Prescott, Edward C."
-      expect(page.find(:css, '[itemprop="abstract"]').text).to eq "This is my abstract"
-      expect(page).not_to have_selector('[itemprop="abstract"][itemtype]')
-      expect(page.find(:css, '[itemprop="identifier"]').text.strip).to eq "https://doi.org/10.21034/sr.600"
-      expect(page).not_to have_selector('[itemprop="identifier"][itemtype]')
-      expect(page.find(:css, '[itemprop="description"]').text.strip).to eq "This is my description"
-      expect(page).not_to have_selector('[itemprop="description"][itemtype]')
-      expect(page.find(:css, '[itemprop="license"][itemprop][itemtype="http://schema.org/CreativeWork"]').text.strip).to eq "Creative Commons BY-NC Attribution-NonCommercial 4.0 International"
+      expect(page).to have_css('[itemprop="abstract"]', text: 'This is my abstract')
+      expect(page).not_to have_css('[itemprop="abstract"][itemtype]')
+      expect(page).to have_css('[itemprop="identifier"]', text: 'https://doi.org/10.21034/sr.600')
+      expect(page).not_to have_css('[itemprop="identifier"][itemtype]')
+      expect(page).to have_css('[itemprop="description"]', text: 'This is my description')
+      expect(page).not_to have_css('[itemprop="description"][itemtype]')
+      expect(page).to have_css('[itemprop="license"][itemtype="http://schema.org/CreativeWork"]', text: "Creative Commons BY-NC Attribution-NonCommercial 4.0 International")
     end
   end
+
   context "dataset without description field" do
     let(:work) { FactoryBot.create(:dataset_without_description) }
     let(:related_url) do
       "Data supports Staff Report 315, \"Does Neoclassical Theory Account for the Effects of Big Fiscal Shocks? Evidence From World War II.\" https://doi.org/10.21034/sr.315"
     end
     it "marks related_url with description schema.org tags" do
-      creator_one
-      creator_two
       visit "/concern/datasets/#{work.id}"
-      expect(page.find(:css, '[itemprop="description"]').text.strip).to eq related_url
+      expect(page).to have_css('[itemprop="description"]', text: related_url)
     end
   end
   context "publications" do
     let(:work) { FactoryBot.create(:populated_publication) }
     it "marks abstract with schema.org tags" do
-      creator_one
-      creator_two
       visit "/concern/publications/#{work.id}"
-      expect(page.find(:css, '[itemprop="abstract"]').text).to eq "This is my abstract"
-      expect(page).not_to have_selector('[itemprop="abstract"][itemtype]')
+      expect(page).to have_css('[itemprop="abstract"]', text: 'This is my abstract')
+      expect(page).not_to have_css('[itemprop="abstract"][itemtype]')
     end
   end
 end


### PR DESCRIPTION
**ISSUE**
Tests of works that have creators associated with the works required an extra step to instantiate creator objects that matched the creator settings on the works.

**RESOULUTION**
This commit refactors the creator and work factories to build or create creator objects as part of the work factory.