### PR TITLE
Refactor CreatorReindexJob to use GlobalID

### DIFF
--- a/app/jobs/creator_reindex_job.rb
+++ b/app/jobs/creator_reindex_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-class CreatorReindexJob < Hyrax::ApplicationJob
-  def perform(creator_id)
-    Creator.find(creator_id).reindex_associated_works
+class CreatorReindexJob < ApplicationJob
+  def perform(creator)
+    creator.reindex_associated_works
   end
 end

--- a/app/models/creator.rb
+++ b/app/models/creator.rb
@@ -6,7 +6,7 @@ class Creator < ApplicationRecord
   after_save :reindex_setup
 
   def reindex_setup
-    CreatorReindexJob.perform_later id
+    CreatorReindexJob.perform_later self
   end
 
   def reindex_associated_works

--- a/spec/jobs/creator_reindex_job_spec.rb
+++ b/spec/jobs/creator_reindex_job_spec.rb
@@ -6,9 +6,8 @@ RSpec.describe CreatorReindexJob, type: :job do
   context 'running the job' do
     it 'calls the method to reindex the associated works' do
       creator = FactoryBot.create(:creator)
-      allow(Creator).to receive(:find).with(creator.id).and_return(creator)
       allow(creator).to receive(:reindex_associated_works)
-      described_class.perform_now(creator.id)
+      described_class.perform_now(creator)
       expect(creator).to have_received(:reindex_associated_works)
     end
   end


### PR DESCRIPTION
**ISSUE**
We had to take extra steps to translate to and from the creator ID in the reindex job, which is unnecessary when passing job arguments using their GlobalID.

**RESOLUTION**
This commit refactors the job to accept a GlobalID parameter instead of a plain ID. This allows us to use Rails capability of automatically loading the corresponding object in the job.