### PR TITLE
Update content_type specs to work with Rails 6.x

### DIFF
--- a/spec/requests/creator_authority_request_spec.rb
+++ b/spec/requests/creator_authority_request_spec.rb
@@ -23,7 +23,7 @@ describe 'Creator authority', type: :request, clean: true do
     it "returns http success and only active creators" do
       get "/authorities/search/creator_authority?q=Ca"
       expect(response).to have_http_status(:success)
-      expect(response.content_type).to eq "application/json"
+      expect(response.content_type).to match "application/json"
       json_body = JSON.parse(response.body)
       expect(json_body.count).to eq 4
       expect(json_body.first["label"]).to eq "Cagetti, Marco"

--- a/spec/requests/creators_spec.rb
+++ b/spec/requests/creators_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "/creators", type: :request, clean: true do
       creator = Creator.create! valid_attributes
       get creator_url(creator), params: { format: :json }
       expect(response).to be_successful
-      expect(response.content_type).to eq "application/json"
+      expect(response.content_type).to match "application/json"
       expect(response.body).not_to be_empty
       expect(response.content_length).to be > 0
       response_values = JSON.parse(response.body)


### PR DESCRIPTION
**ISSUE**
Rails 6+ will return a more detailed content type that includes the character encoding:
* Rails 5: 'application/json'
* Rails 6: 'application/json; charset=utf-8'

**RESOULUTION**
Updating the matcher from `eq` to `match` allows the test suite to run successfully against either Rails version.