### PR TITLE
Remove redundant code in RDF::Markdown::Literal class

### DIFF
--- a/app/lib/rdf/markdown/literal.rb
+++ b/app/lib/rdf/markdown/literal.rb
@@ -19,16 +19,6 @@ module RDF
 
       # support ActiveJob serialization
       include GlobalID::Identification
-      ##
-      # Initializes an RDF::Literal with Mardown datatype.
-      #
-      # Casts lexical values to {String}. Parsing is left as an excerise for the
-      # reader.
-      #
-      # @see {RDF::Literal}
-      def initialize(value, options = {})
-        super
-      end
 
       def self.find(id)
         new(id)


### PR DESCRIPTION
**RATIONALE**
Since the initializer just calls `super` we can remove it. Ruby will call the superclass initializer by default when it is not overriden in the child class.