### PR TITLE
Refactor works in anticipation of Hyrax 5 & Rails 6

### DIFF
--- a/app/models/conference_proceeding.rb
+++ b/app/models/conference_proceeding.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
-class ConferenceProceeding < CypripediumWork
+class ConferenceProceeding < ActiveFedora::Base
+  validates :title, presence: { message: 'Your work must have a title.' }
+
+  include Hyrax::WorkBehavior
+  include Cypripedium::Metadata
+  include ::Hyrax::BasicMetadata
+
+  self.indexer = CypripediumIndexer
 end

--- a/app/models/creator.rb
+++ b/app/models/creator.rb
@@ -13,7 +13,7 @@ class Creator < ApplicationRecord
     solr = Blacklight.default_index.connection
     response = solr.get 'select', params: { q: "creator_id_ssim:#{id}" }
     response['response']['docs'].each do |doc|
-      CypripediumWork.find(doc['id']).update_index
+      ActiveFedora::Base.find(doc['id']).update_index
     end
   end
 

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
-class Dataset < CypripediumWork
+class Dataset < ActiveFedora::Base
+  validates :title, presence: { message: 'Your work must have a title.' }
+
+  include Hyrax::WorkBehavior
+  include Cypripedium::Metadata
+  include ::Hyrax::BasicMetadata
+
+  self.indexer = CypripediumIndexer
 end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
-class Publication < CypripediumWork
+class Publication < ActiveFedora::Base
+  validates :title, presence: { message: 'Your work must have a title.' }
+
+  include Hyrax::WorkBehavior
+  include Cypripedium::Metadata
+  include ::Hyrax::BasicMetadata
+
+  self.indexer = CypripediumIndexer
 end


### PR DESCRIPTION
**ISSUE**
Rails class autoloading of work classes subclassed from CypripediumWork fails after the Hyrax 5 & Rails 6 upgrade.

**RESOLUTION**
This commit reverts the subclassing of work types under CypripediumWork. Each work class is now a direct descendant of ActiveFedora::Base. We may revisit the possibility of DRY-ing up the work class definitions after the Hyrax 5 upgrade has been completed; for now, this appears to be the path of greatest success.