### PR TITLE
Extract Hyrax generated CSS requires

### DIFF
--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -1,0 +1,16 @@
+/* ...
+ *= require jquery-ui
+ *= require select2
+ *= require_self
+*/
+
+@import "bootstrap-default-overrides";
+@import 'bootstrap';
+@import "font-awesome";
+@import "blacklight_gallery/gallery";
+@import "blacklight_gallery/masonry";
+@import "blacklight_gallery/slideshow";
+@import "blacklight_gallery/osd_viewer";
+@import "hyrax/blacklight_gallery";
+@import 'hyrax/hyrax';
+@import 'hyrax/login_signup';

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -1,21 +1,7 @@
 /* ...
- *= require jquery-ui
- *= require select2
+ *= require hyrax
  *= require_self
 */
-
-@import "bootstrap-default-overrides";
-@import 'bootstrap';
-@import 'blacklight/blacklight';
-@import "font-awesome";
-@import "blacklight_gallery/gallery";
-@import "blacklight_gallery/masonry";
-@import "blacklight_gallery/slideshow";
-@import "blacklight_gallery/osd_viewer";
-@import "hyrax/blacklight_gallery";
-@import 'hyrax/hyrax';
-@import 'hyrax/login_signup';
-
 
 body.dashboard {
   padding-top: 73px;


### PR DESCRIPTION
**ISSUE**
We want to ensure our local changes override Hyrax styles, so we want to require the Hyrax bolierplate styling _before_ our local changes.

**RESOLUTION**
Create a hyrax.scss that matches the one
[generated by Hrax 5.x](https://github.com/samvera/hyrax/blob/hyrax-v5.0.1/lib/generators/hyrax/templates/hyrax.scss) and explictly require it before our local changes.