### PR TITLE
Update homepage main content styling

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -126,14 +126,44 @@ to match orgnizational style guidelines
 HOMEPAGE Main Content Styling tweaks
  */
 
-#recent_docs .table {
-    width: 100%;
-    max-width: 100%;
-    margin-bottom: 0;
-}
+.home-content {
+  padding-bottom: 2.5rem;
 
-.media-body {
-  width: auto;
+  // Align the Welcome paragraph with Recently Added Items
+  div.col-xs-12 {
+    padding-left: 1rem;
+  }
+
+  // Approximate FRBM feature link styling
+  a {
+    color: var(--frbm-dark-contrast-blue);
+    font-weight: bold;
+  }
+
+  .recent-item, .featured-collection {
+    a {
+      font-weight: normal;
+    }
+
+    h4 a {
+      font-weight: bold;
+      color: var(--frbm-dark-blue);
+    }
+  }
+
+  // Match Collection Highlights styling to Recent Documents styling
+  ul.collection-highlights {
+    list-style: none;
+
+    li.featured-collection {
+      border-top: 1px solid #ddd;
+
+      img {
+        border: none;
+        height: auto;
+      }
+    }
+  }
 }
 
 /*

--- a/app/views/hyrax/homepage/_explore_collections.html.erb
+++ b/app/views/hyrax/homepage/_explore_collections.html.erb
@@ -1,20 +1,21 @@
-<table class="table table-hover">
-    <% collections.each do |collection| %>
-      <tr>
-        <td class="col-sm-2">
-            <%= link_to [hyrax, collection], class: 'media-left', 'aria-hidden' => true do %>
-              <%= render_thumbnail_tag collection, { width: 45 }, suppress_link: true %>
+<ul id="home-collections" class="inline-list list-group collection-highlights">
+  <% collections.each do |collection| %>
+    <li class="featured-collection">
+      <div class="row">
+        <div class="col-sm-12">
+          <h4>
+            <%= link_to [hyrax, collection], class: 'media-left' do %>
+              <%= document_presenter(collection)&.thumbnail&.thumbnail_tag(
+                    { width: 90, alt: "#{collection} #{ t('hyrax.homepage.admin_sets.thumbnail')}" },
+                    { suppress_link: true }
+                  ) %>
+              <%= collection.title_or_label %>
             <% end %>
-          </td>
-          <td>
-                <%= link_to [hyrax, collection] do %>
-                <h4>  <%= collection.title_or_label %></h4>
-                <% end %>
-        </td>
-      </tr>
-    <% end %>
-</table>
-<ul class="list-inline collection-highlights-list">
+          </h4>
+        </div>
+      </div>
+    </li>
+  <% end %>
   <li>
     <%= link_to t('hyrax.homepage.admin_sets.link'),
                 main_app.search_catalog_path(f: { human_readable_type_sim: ["Collection"]}),

--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -1,17 +1,16 @@
-<div class="col-xs-12">
-  <h3>Welcome to the Research Database</h3>
-<p>
-  The Research Database is the institutional repository for research conducted by economists affiliated with the <a href="https://minneapolisfed.org/economic-research">Federal Reserve Bank of Minneapolis Research Division</a>.
-  The Research Database contains over 50 years of content including preprints, working papers, data, archival publications and conference proceedings. Get started by entering your search terms, viewing recent additions, or browsing by collection.</p>
-
+<div class="col-xs-12 welcome-message">
+  <h2>Welcome to the Research Database</h2>
+  <p>
+    The Research Database is the institutional repository for research conducted by economists affiliated with the <a href="https://minneapolisfed.org/economic-research">Federal Reserve Bank of Minneapolis Research Division</a>.
+    The Research Database contains over 50 years of content including preprints, working papers, data, archival publications and conference proceedings. Get started by entering your search terms, viewing recent additions, or browsing by collection.
+  </p>
 </div>
 <div class="col-xs-12 col-sm-6">
-<h3>Recently Added Items</h3>
-    <%= render 'recently_uploaded', recent_documents: @recent_documents %>
-
-</div><!-- /.col-xs-6 -->
+  <h3>Recently Added Items</h3>
+  <%= render 'recently_uploaded', recent_documents: @recent_documents %>
+</div>
 
 <div class="col-xs-12 col-sm-6">
-<h3>Collections</h3>
-      <%= render 'explore_collections', collections: @presenter.collections %>
-    </div>
+  <h3>Collections</h3>
+  <%= render 'explore_collections', collections: @presenter.collections %>
+</div>

--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -1,21 +1,23 @@
-<table class="table table-hover">
-<tr>
-  <td class="col-sm-2">
-    <%= link_to [main_app, recent_document] do %>
-      <%= render_thumbnail_tag recent_document, { width: 45 }, suppress_link: true %>
-    <% end %>
-  </td>
-  <td>
-    <h4>
-      <span class="sr-only">Title</span><%= link_to truncate(recent_document.to_s, length: 100, separator: ' '), [main_app, recent_document] %>
-    </h4>
-    <p>
-      <span class="sr-only">Authors</span><%= link_to_facet_list(recent_document.alpha_creator, 'creator', '', ' / ' ).html_safe %>
-    </p>
-    <p>
-      <span class="sr-only">Series</span><%= link_to_facet_list(recent_document.series, 'series', '').html_safe %>
-      <span class="sr-only">Issue Number</span><%= link_to_facet_list(recent_document.issue_number, 'issue_number', '').html_safe %>
-    </p>
-</td>
-</tr>
-</table>
+<li class="recent-item">
+  <div class="row">
+    <div class="col-sm-12">
+      <%= link_to [main_app, recent_document] do %>
+        <%= document_presenter(recent_document)&.thumbnail&.thumbnail_tag(
+              { width: 90, alt: "#{recent_document} #{ t('hyrax.homepage.admin_sets.thumbnail')}" },
+              { suppress_link: true }
+            ) %>
+      <% end %>
+      <h4 class="recent-field">
+        <span class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></span>
+        <%= link_to truncate(recent_document.to_s, length: 100, separator: ' '), [main_app, recent_document] %>
+      </h4>
+      <p class="recent-field">
+        <span class="sr-only">Authors</span><%= link_to_facet_list(recent_document.alpha_creator, 'creator', '', ' / ' ).html_safe %>
+      </p>
+      <p class="recent-field">
+        <span class="sr-only">Series</span><%= link_to_facet_list(recent_document.series, 'series', '').html_safe %>
+        <span class="sr-only">Issue Number</span><%= link_to_facet_list(recent_document.issue_number, 'issue_number', '').html_safe %>
+      </p>
+    </div>
+  </div>
+</li>

--- a/app/views/hyrax/homepage/_recently_uploaded.html.erb
+++ b/app/views/hyrax/homepage/_recently_uploaded.html.erb
@@ -1,9 +1,0 @@
-<h2 class="sr-only"><%= t('hyrax.homepage.recently_uploaded.title') %></h2>
-<% if recent_documents.blank? %>
-  <p><%= t('.no_public') %></p>
-<% else %>
-  <div id="recent_docs">
-      <tr>
-    <%= render partial: "recent_document", collection: recent_documents %></tr>
-  </div>
-<% end %>


### PR DESCRIPTION
This change updates the homepage content styling to better reflect organizational branding after the changes introduced by Hyrax 5 (& Bootstrap 4).

We've removed previously overriden files from earlier releases because the current Hyrax 5 versions are a sufficiently clean fit without modification.

We've updated other overridden files to more closely follow the current structure and markup of their Hyrax counterparts.