### PR TITLE
Add system test for new work creation

### DIFF
--- a/spec/system/new_work_workflow_spec.rb
+++ b/spec/system/new_work_workflow_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'New work creation', type: :system, js: true do
+  let(:admin_user) { FactoryBot.create(:admin) }
+
+  before do
+    # Create legacy default AdminSet (ActiveFedora)
+    # Mimics Hyrax::AdminSetCreateService, but persists the default admin set to Fedora instead of the Database
+    default_admin_set = AdminSet.where(id: 'admin_set/default').first ||
+                        AdminSet.create!(id: 'admin_set/default', title: ['Default Admin Set'])
+    permission_template = Hyrax::Collections::PermissionsCreateService.create_default(collection: default_admin_set, creating_user: nil)
+    Hyrax::AdminSetCreateService.new(admin_set: default_admin_set, creating_user: nil).send(:create_workflows_for, permission_template: permission_template)
+    # add deposit rights for registered users here if required
+  end
+
+  example 'administrative deposit', :aggregate_failures do
+    login_as(admin_user)
+
+    visit hyrax.dashboard_path
+    click_on 'Works'
+    click_on id: 'add-new-work-button'
+    choose 'Publication'
+    click_button I18n.t('hyrax.dashboard.heading_actions.create_work')
+    fill_in id: 'publication_title', with: 'My new Publication'
+    fill_in id: 'publication_series', with: 'Staff Reports'
+    choose 'publication_visibility_open'
+    check 'agreement'
+    click_on 'Files'
+    within('div#add-files') do
+      attach_file("files[]", "spec/fixtures/files/pdf-sample.pdf", visible: false)
+    end
+    click_on 'Save'
+    expect(page).to have_content('My new Publication')
+    expect(page).to have_selector('span.badge', text: 'Public')
+    edit_link = page.find_link('Edit')['href']
+    expect(edit_link).to match edit_hyrax_publication_path(Publication.last)
+  end
+end


### PR DESCRIPTION
**ISSUE**
Attempting to upgrade from Hyrax v5.0.1 to v5.0.4 broke the ability to add new works to the repostory via the UI.

**RESPONSE**
This change adds a test for the basic happy path for creating a new item in the repository. This test should help us identify which step of the upgrade process might break the deposit UI.