### PR TITLE
Disable animations during test suite

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
 # Setup chrome headless driver
-Capybara.server = :puma, { Silent: true }
-
 Capybara.register_driver :chrome_headless do |app|
   client = Selenium::WebDriver::Remote::Http::Default.new
   client.read_timeout = 120
 
   options = ::Selenium::WebDriver::Chrome::Options.new
-  options.add_argument('--headless')
+  options.add_argument('--headless=new')
   options.add_argument('--no-sandbox')
   options.add_argument('--disable-dev-shm-usage')
   options.add_argument('--window-size=1400,1400')
@@ -16,9 +14,14 @@ Capybara.register_driver :chrome_headless do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options, http_client: client)
 end
 
+# Configure Capybara
+Capybara.server = :puma, { Silent: true }
 Capybara.javascript_driver = :chrome_headless
 
-# Setup rspec
+# Disable animations during test suite, this helps make testing certain bootstrap elements like modals more reliable
+Capybara.disable_animation
+
+# Override Rails System Test default driver - driven_by(:selenium)
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :rack_test


### PR DESCRIPTION
**ISSUE**
Some Bootstrap animations do not always complete before subsequent test steps are executed by Capybara. This has resulted in a number of flapping system tests.

**RESOLUTION**
Configure Capybara to disable animations when running tests.

**REFERENCE**
* https://scottbartell.com/2020/07/06/capybara-tip-disable-animations/
* https://github.com/teamcapybara/capybara/blob/3.40.0/lib/capybara/server/animation_disabler.rb
* [Historical] https://github.com/samvera/hyrax/blob/d3a0b3bc2177ecf6aa2b49efda8089ad0fc171a2/spec/test_app_templates/disable_animations_in_test_environment.rb

**NOTE**
This change also includes an update to the Chromium headless driver to make headless testing match live browser behavior more exactly. See https://www.selenium.dev/blog/2023/headless-is-going-away/