### PR TITLE
Fix broken new work creation workflow

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,29 +12,18 @@
 //
 
 //= require tether
-/* removed b/c it currently breaks modals */
-// require browse_everything
-
 //= require activestorage
 //= require rails-ujs
 //= require turbolinks
-
 //= require jquery3
 //= require popper
 //= require twitter/typeahead
-//= require bootstrap
-
 //= require jquery.dataTables
 //= require dataTables.bootstrap4
 //= require blacklight/blacklight
 //= require blacklight_gallery/default
-//= require bootstrap-sprockets
-//= require cable
-//= require notification-sort
-//= require almond
-//= require creator_id
-//= require hydra-editor/field_manager
 //= require blacklight_range_limit
+//= require bootstrap-sprockets
+//= require hyrax
 
 //= require_tree .
-//= require hyrax

--- a/spec/fixtures/files/tiny.txt
+++ b/spec/fixtures/files/tiny.txt
@@ -1,0 +1,1 @@
+Sample for upload test.

--- a/spec/system/new_work_workflow_spec.rb
+++ b/spec/system/new_work_workflow_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'New work creation', type: :system, js: true do
+  let(:admin_user) { FactoryBot.create(:admin) }
+
+  before do
+    # Create legacy default AdminSet (ActiveFedora)
+    # Mimics Hyrax::AdminSetCreateService, but persists the default admin set to Fedora instead of the Database
+    default_admin_set = AdminSet.where(id: 'admin_set/default').first ||
+                        AdminSet.create!(id: 'admin_set/default', title: ['Default Admin Set'])
+    permission_template = Hyrax::Collections::PermissionsCreateService.create_default(collection: default_admin_set, creating_user: nil)
+    Hyrax::AdminSetCreateService.new(admin_set: default_admin_set, creating_user: nil).send(:create_workflows_for, permission_template: permission_template)
+    # add deposit rights for registered users here if required
+  end
+
+  example 'administrative deposit', :aggregate_failures do
+    login_as(admin_user)
+    visit hyrax.dashboard_path
+    click_on 'Works'
+    click_on 'Add New Work'
+    choose 'Publication'
+    click_button 'Create work'
+    expect(page).to have_content('New Publication')
+    fill_in id: 'publication_title', with: 'My new Publication'
+    fill_in id: 'publication_series', with: 'Staff Reports'
+    choose 'publication_visibility_open'
+    click_on 'Files'
+    find(id: 'addfiles', visible: :any).attach_file('spec/fixtures/files/tiny.txt')
+    check 'agreement'
+    click_on 'Save'
+    expect(page).to have_content('My new Publication')
+    expect(page).to have_selector('span.badge', text: 'Public')
+    edit_link = page.find_link('Edit')['href']
+    expect(edit_link).to match edit_hyrax_publication_path(Publication.last)
+  end
+end


### PR DESCRIPTION
**ISSUE**
After the upgrade to Hyrax v5.0.4 the "Add New Work" button in the administrator dashboard stopped working. This prevents repository administrators from creating new works via the dashboard UI.

**DIAGNOSIS**
The problem was tracked down to an issue with the Javascript load order and timeout issues due to asynchronous Javascript initialization.

**RESOULTION**
The timeout issues were addressed in https://github.com/curationexperts/cypripedium/pull/658.

This change adds a test that emulates the failing UI workflow, and modifies the Javascript load order as required to fix the problem.