### PR TITLE
Update Sidekiq to latest release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'redcarpet'
 gem 'riiif', '~> 2.1'
 gem 'rsolr', '>= 1.0', '< 3'
 gem 'rubyzip', '~> 1.0', require: 'zip'
-gem 'sidekiq', '~> 6.4'
+gem 'sidekiq', '< 8'
 gem 'solrizer'
 gem 'strscan', '1.0.3' # match version installed on server as system gem
 gem 'terser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -863,6 +863,8 @@ GEM
     redic (1.5.3)
       hiredis
     redis (4.8.1)
+    redis-client (0.23.2)
+      connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)
     redlock (1.3.2)
@@ -975,10 +977,12 @@ GEM
       rdf-xsd (~> 3.3)
       sparql (~> 3.3)
       sxp (~> 1.3)
-    sidekiq (6.5.12)
-      connection_pool (>= 2.2.5, < 3)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
+    sidekiq (7.3.9)
+      base64
+      connection_pool (>= 2.3.0)
+      logger
+      rack (>= 2.2.4)
+      redis-client (>= 0.22.2)
     signet (0.19.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -1172,7 +1176,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubyzip (~> 1.0)
   selenium-webdriver
-  sidekiq (~> 6.4)
+  sidekiq (< 8)
   simplecov
   simplecov-lcov
   solrizer


### PR DESCRIPTION
**ISSUE**
Since upgrading to Hyrax 5, we are experiencing issues with background jobs after deploying to production. Thumbnails (i.e. derivative files) are not being attached
to newly created works.

**RATIONALE**
Before attempting to debug the issue further, we want to ensure we are running the most recent compatible version of Sidekiq to check whether that resolves the issues we're seeing.

We've noticed that the sidekiq service is not restarting (i.e. reloading with updated application code) when deploying to prod-like environments using Capistrano. We have a hypothesis that we may need to re-generate the Systemd service files for Sidekiq.