### PR TITLE
Update Sidekiq to latest release

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -19,13 +19,6 @@ install_plugin Capistrano::Sidekiq::Systemd
 set :sidekiq_service_unit_user, :system # Run Sidekiq as a system service
 
 # Load the SCM plugin appropriate to your project:
-#
-# require "capistrano/scm/hg"
-# install_plugin Capistrano::SCM::Hg
-# or
-# require "capistrano/scm/svn"
-# install_plugin Capistrano::SCM::Svn
-# or
 require "capistrano/scm/git"
 install_plugin Capistrano::SCM::Git
 

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'redcarpet'
 gem 'riiif', '~> 2.1'
 gem 'rsolr', '>= 1.0', '< 3'
 gem 'rubyzip', '~> 1.0', require: 'zip'
-gem 'sidekiq', '~> 6.4'
+gem 'sidekiq', '< 8'
 gem 'solrizer'
 gem 'strscan', '1.0.3' # match version installed on server as system gem
 gem 'terser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -863,6 +863,8 @@ GEM
     redic (1.5.3)
       hiredis
     redis (4.8.1)
+    redis-client (0.23.2)
+      connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)
     redlock (1.3.2)
@@ -975,10 +977,12 @@ GEM
       rdf-xsd (~> 3.3)
       sparql (~> 3.3)
       sxp (~> 1.3)
-    sidekiq (6.5.12)
-      connection_pool (>= 2.2.5, < 3)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
+    sidekiq (7.3.9)
+      base64
+      connection_pool (>= 2.3.0)
+      logger
+      rack (>= 2.2.4)
+      redis-client (>= 0.22.2)
     signet (0.19.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -1172,7 +1176,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubyzip (~> 1.0)
   selenium-webdriver
-  sidekiq (~> 6.4)
+  sidekiq (< 8)
   simplecov
   simplecov-lcov
   solrizer

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -12,6 +12,13 @@ set :log_level, :error
 set :bundle_flags, '--deployment'
 set :bundle_env_variables, nokogiri_use_system_libraries: 1
 
+# Sidekiq configuration on servers
+set :sidekiq_roles, :worker                  # Default role for Sidekiq processes
+set :sidekiq_default_hooks, true             # Enable default deployment hooks
+set :sidekiq_env, fetch(:rack_env, fetch(:rails_env, fetch(:stage))) # Environment for Sidekiq processes
+set :service_unit_user, :system              # We run Sidekiq as a system service to avoid setting up lingering
+set :sidekiq_service_unit_name, 'sidekiq'    # Match the service name configured by Ansible
+
 set :keep_releases, 3
 set :assets_prefix, "#{shared_path}/public/assets"
 

--- a/config/deploy/ssm.rb
+++ b/config/deploy/ssm.rb
@@ -17,7 +17,7 @@ set :instance_id, lambda {
                        Name=tag-key,Values=Project Name=tag-value,Values=rdb \
                        --query "Reservations[*].Instances[*].InstanceId" --output text`.chomp
 }
-server fetch(:instance_id), user: 'deploy', roles: [:web, :app, :db]
+server fetch(:instance_id), user: 'deploy', roles: [:web, :app, :db, :worker]
 set :command, %(aws --profile frbm-ssm  ssm start-session --target %h --document-name AWS-StartSSHSession --parameters 'portNumber=%p')
 set :ssh_options,
   auth_methods: %w[publickey],


### PR DESCRIPTION
**ISSUE**
Since upgrading to Hyrax 5, we are experiencing issues with background jobs after deploying to production. Thumbnails (i.e. derivative files) are not being attached to newly created works.

**DIAGNOSIS**
Sidekiq workers were not being restarted with updated code on deploys due to multiple issues with the Sidekiq configuration.

**FIX**
Update to the most recent version of Sidekiq and update Capistrano deployment configuration files to ensure sidekiq workers are restarted with the newly deployed code during the `cap deploy` process.