### PR TITLE
Fix Valkyrie derivative storage location

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -120,3 +120,8 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 end
+
+# Set the production derivatives path, unless it is already set in
+# the environment. This allows the Valkyrie Storage Adapter to initialize correctly
+# See https://github.com/samvera/hyrax/blob/v5.0.4/config/initializers/storage_adapter_initializer.rb#L10:
+ENV['HYRAX_DERIVATIVES_PATH'] ||= '/opt/derivatives'

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -188,7 +188,7 @@ Hyrax.config do |config|
   # Location on local file system where derivatives will be stored
   # If you use a multi-server architecture, this MUST be a shared volume
   # config.derivatives_path = Rails.root.join('tmp', 'derivatives')
-  config.derivatives_path = '/opt/derivatives' if Rails.env.production?
+  # NOTE: the default value is overridden in the production environment
 
   # Should schema.org microdata be displayed?
   config.display_microdata = true


### PR DESCRIPTION
**ISSUE**
Since upgrading to Hyrax 5, we are experiencing issues with Thumbnails (i.e. derivative files) are not being attached to newly created works.

**DIAGNOSIS**
The Valkyrie Storage Adapter intializer at
https://github.com/samvera/hyrax/blob/v5.0.4/config/initializers/storage_adapter_initializer.rb#L10 is run during engine (gem) initialization which happens BEFORE local application initializers are run. This causes the system to use the default value for `Hyrax.config.derivatives_path` rather than the value set later in the local application
via `config/initializers/hyrax.rb`

In order to ensure all relevent subsystems and engines have access to the correct value, we're injecting it into the server environment.

**BEFORE**
Files being stored to `tmp/derivatives`
```
> Hyrax.config.derivatives_storage_adapter
=> 
#<Valkyrie::Storage::Disk:0x00007f68cf8a7318                                                                          
 @base_path=#<Pathname:/opt/cypripedium/releases/20250220212337/tmp/derivatives>,                                     
 @file_mover=#<Method: FileUtils.mv(src, dest, force: ..., noop: ..., verbose: ..., secure: ...) /usr/local/lib/ruby/3.2.0/fileutils.rb:1169>,
 @path_generator=                                                                                                     
  #<Hyrax::DerivativeBucketedStorage:0x00007f68cf8a71b0 @base_path=#<Pathname:/opt/cypripedium/releases/20250220212337/tmp/derivatives>>>
```

**AFTER**
Files being stored to absolute path `/opt/derivatives`
```
> Hyrax.config.derivatives_storage_adapter
=> 
#<Valkyrie::Storage::Disk:0x00007f32d6b91490              
 @base_path=#<Pathname:/opt/derivatives>,
 @file_mover=#<Method: FileUtils.mv(src, dest, force: ..., noop: ..., verbose: ..., secure: ...) /usr/local/lib/ruby/3.2.0/fileutils.rb:1169>,
 @path_generator=#<Hyrax::DerivativeBucketedStorage:0x00007f32d6b91350 @base_path="/opt/derivatives">>
```
