### PR TITLE
Update Extra-Small bootstrap references

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -147,11 +147,6 @@ HOMEPAGE Main Content Styling tweaks
 .home-content {
   padding-bottom: 2.5rem;
 
-  // Align the Welcome paragraph with Recently Added Items
-  div.col-xs-12 {
-    padding-left: 1rem;
-  }
-
   // Approximate FRBM feature link styling
   a {
     color: var(--frbm-dark-contrast-blue);

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -11,7 +11,7 @@
 <% end %>
 
 <div itemscope itemtype="<%= itemtype %>" class="row">
-  <div class="col-xs-12">
+  <div class="col-12">
     <header>
       <%= render 'work_title', presenter: @presenter %>
     </header>

--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -1,16 +1,16 @@
-<div class="col-xs-12 welcome-message">
+<div class="col-12 welcome-message">
   <h2>Welcome to the Research Database</h2>
   <p>
     The Research Database is the institutional repository for research conducted by economists affiliated with the <a href="https://minneapolisfed.org/economic-research">Federal Reserve Bank of Minneapolis Research Division</a>.
     The Research Database contains over 50 years of content including preprints, working papers, data, archival publications and conference proceedings. Get started by entering your search terms, viewing recent additions, or browsing by collection.
   </p>
 </div>
-<div class="col-xs-12 col-sm-6">
+<div class="col-12 col-sm-6">
   <h3>Recently Added Items</h3>
   <%= render 'recently_uploaded', recent_documents: @recent_documents %>
 </div>
 
-<div class="col-xs-12 col-sm-6">
+<div class="col-12 col-sm-6">
   <h3>Collections</h3>
   <%= render 'explore_collections', collections: @presenter.collections %>
 </div>


### PR DESCRIPTION
Bootstrap 4.x drops the col-xs-# column settings in favor of merging them with col-#.

**REFERENCE**
https://getbootstrap.com/docs/4.2/migration/#grid-system