### PR TITLE
Fix broken homepage link to collections

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -53,6 +53,8 @@ class CatalogController < ApplicationController
     # The generic_type isn't displayed on the facet list
     # It's used to give a label to the filter that comes from the user profile
     config.add_facet_field solr_name("generic_type", :facetable), if: false
+    # Configure a friendly label for has_model_ssim
+    config.add_facet_field solr_name('has_model', :symbol, multiple: true), label: 'Type', if: false
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/app/views/hyrax/homepage/_explore_collections.html.erb
+++ b/app/views/hyrax/homepage/_explore_collections.html.erb
@@ -18,7 +18,8 @@
   <% end %>
   <li>
     <%= link_to t('hyrax.homepage.admin_sets.link'),
-                main_app.search_catalog_path(f: { human_readable_type_sim: ["Collection"]}),
+                main_app.search_catalog_path(f: { has_model_ssim: ["Collection"]}),
+                id: 'all_collections',
                 class: 'btn btn-default' %>
   </li>
 </ul>

--- a/spec/system/collection_link_spec.rb
+++ b/spec/system/collection_link_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Collections listing', type: :system do
+  let(:admin_user) { FactoryBot.create(:admin) }
+  let(:collection) do
+    Collection.create!(
+      title: ['Collection 1'],
+      collection_type: Hyrax::CollectionType.find_or_create_default_collection_type,
+      description: ['A Collection']
+    )
+  end
+  let(:titles) do
+    [
+      'Work One',
+      'Work Two'
+    ]
+  end
+  let(:collection_members) do
+    titles.each.with_index(1) do |title, i|
+      FactoryBot.create(:publication,
+                        title: [title],
+                        depositor: admin_user.user_key,
+                        member_of_collections: [collection])
+    end
+  end
+
+  before do
+    collection_members
+    login_as admin_user
+  end
+
+  context 'from homepage link' do
+    it 'displays only collections', :aggregate_failures do
+      visit root_path
+      click_on 'all_collections'
+      expect(page).to have_content 'A Collection'
+      expect(page).not_to have_content 'Work One'
+      expect(page).not_to have_content 'Work Two'
+    end
+  end
+end


### PR DESCRIPTION
**ISSUE**
The "View All Collections" button on the hompage no longer displays a list of collections, it takes the user to a search result page showing all items in the repository.

**RESOLUTION**
Configure an inaccessible facet for the model ("Type") and update the link to a search for all items with model == Collection.