### PR TITLE
Add (missing) sort and per-page options in search results

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -29,6 +29,10 @@ class CatalogController < ApplicationController
     config.show.partials.insert(1, :openseadragon)
     config.search_builder_class = Hyrax::CatalogSearchBuilder
 
+    config.add_results_collection_tool(:sort_widget)
+    config.add_results_collection_tool(:per_page_widget)
+    # config.add_results_collection_tool(:view_type_group) # list | gallery | masonry | slideshow
+
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {
       qt: "search",


### PR DESCRIPTION
**ISSUE**
The sorting and page-size options are missing from search results after the Hyrax 5 upgrade.

**DIAGNOSIS**
Blacklight 7 now provides these UI components via individual configuration in the Catalog Controller rather than including them by default. The options are included when a new application generates a new catalog controller.

**RESOLUTION**
Since we're upgrading from a previous version
of Blacklight, we need to manually add these components.