### PR TITLE
Fix flaky test

### DIFF
--- a/spec/system/collection_link_spec.rb
+++ b/spec/system/collection_link_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.describe 'Collections listing', type: :system do
+RSpec.describe 'Collections listing', type: :system, clean: true do
   let(:admin_user) { FactoryBot.create(:admin) }
   let(:collection) do
     Collection.create!(


### PR DESCRIPTION
**ISSUE**
The test was failing because with some random seeds, the tests were setting up collection types and persisting the default ID before this test was run, and then deleting the database object corresponding to the persisted id.

The error looked like this:
```
  1) Collections listing from homepage link displays only collections
     Failure/Error: click_on 'all_collections'

     ActionView::Template::Error:
       Couldn't find Hyrax::CollectionType with 'id'=2
     # ./spec/system/collection_link_spec.rb:37:in `block (3 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # ActiveRecord::RecordNotFound:
     #   Couldn't find Hyrax::CollectionType with 'id'=2
     #   ./spec/system/collection_link_spec.rb:37:in `block (3 levels) in <top (required)>'
```

**RESOLUTION**
Force clean Fedora before running the test to eliminate mis-matches between IDs and persisted objects.