### PR TITLE
Fix test that fails when JS takes too long to execute

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,6 +43,7 @@ RSpec.configure do |config|
   config.before :suite do
     DatabaseCleaner.clean_with(:truncation)
     ActiveFedora::Cleaner.clean!
+    ActiveJob::Base.queue_adapter = :test
   end
 
   config.before do

--- a/spec/system/new_work_workflow_spec.rb
+++ b/spec/system/new_work_workflow_spec.rb
@@ -29,7 +29,16 @@ RSpec.describe 'New work creation', type: :system, js: true do
     click_on 'Files'
     find(id: 'addfiles', visible: :any).attach_file('spec/fixtures/files/tiny.txt')
     check 'agreement'
+
+    # Yield control back to the browser until the Javascript upload completes
+    # i.e. there is a delete button next to the uploaded file
+    page.find('tbody.files') until page.find('button.delete')
     click_on 'Save'
+
+    # Yield control back to the browser until the page redirects to the Publication view
+    page.find(id: 'with_files_submit') until page.find('.work-title-wrapper span[itemprop="name"]')
+    # The page should redirect to the newly created Publication
+    expect(current_path).to match(hyrax_publication_path(Publication.last))
     expect(page).to have_content('My new Publication')
     expect(page).to have_selector('span.badge', text: 'Public')
     edit_link = page.find_link('Edit')['href']


### PR DESCRIPTION
**ISSUE**
The New Work Workflow test is failing intermittently because the expected page changes are not always rendered in the expected timeframe.

**DIAGNOSIS**
Although Capybara expectations are generally good at waiting for the browser to render the expected elements, they don't wait long enough for some of Hyrax's heavier weight JS to execute.

**RESOLUTION**
Add explicit wait loops that pause test execution until the expected transitions render successfully.