### PR TITLE
Output semantic metadata to logs in JSON format (backport)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ gem 'pg'
 gem 'puma'
 gem 'rails', '~> 5'
 gem 'rails-assets-tether'
+# Support semantic logs in JSON format [https://logger.rocketjob.io/rails.html]
+gem 'rails_semantic_logger'
 gem 'rainbow'
 gem 'redcarpet'
 gem 'redis', '~> 4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -697,6 +697,10 @@ GEM
       actionview (> 3.1)
       activesupport (> 3.1)
       railties (> 3.1)
+    rails_semantic_logger (4.14.0)
+      rack
+      railties (>= 5.1)
+      semantic_logger (~> 4.13)
     railties (5.2.8.1)
       actionpack (= 5.2.8.1)
       activesupport (= 5.2.8.1)
@@ -877,6 +881,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    semantic_logger (4.15.0)
+      concurrent-ruby (~> 1.0)
     shacl (0.1.1)
       json-ld (~> 3.1, >= 3.1.7)
       rdf (~> 3.1, >= 3.1.8)
@@ -1069,6 +1075,7 @@ DEPENDENCIES
   puma
   rails (~> 5)
   rails-assets-tether
+  rails_semantic_logger
   rainbow
   redcarpet
   redis (~> 4.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,4 +21,11 @@ class ApplicationController < ActionController::Base
     params.delete('locale')
     render file: Rails.root.join('app', 'views', 'static', 'not_acceptable.html.erb'), status: :not_acceptable, layout: true
   end
+
+  private
+
+  def append_info_to_payload(payload)
+    super
+    payload[:request_id] = request.request_id
+  end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationJob < ActiveJob::Base
+  def perform_now
+    SemanticLogger.tagged(job_class: self.class, job_id: job_id) { super }
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,9 @@ module Cypripedium
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    # Output logs in JSON format
+    config.rails_semantic_logger.format = :json
+    config.semantic_logger.application = Rails.version < '6' ? Rails.application.class.parent.name : Rails.application.class.module_parent_nam
   end
 end


### PR DESCRIPTION
In order to easily use search and filtering capabilities in log aggregation and analysis tools like AWS CloudWatch logs, we want to send our logs in an easily parsable format.

We've chosen [Semantic Logger](https://logger.rocketjob.io/index.html) because it provides an easy drop-in replacement for the default Rails logger. Semantic Logger doesn't require us to change any of our existing logging code and makes it simple to output logs in JSON format.