### PR TITLE
Output semantic metadata to logs in JSON format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem 'parser'
 gem 'pg', '~> 1.3'
 gem 'puma'
 gem 'rails', '~> 6.1'
+# Support semantic logs in JSON format [https://logger.rocketjob.io/rails.html]
+gem 'rails_semantic_logger'
 gem 'redcarpet'
 gem 'riiif', '~> 2.1'
 gem 'rsolr', '>= 1.0', '< 3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -773,6 +773,10 @@ GEM
       actionview (> 3.1)
       activesupport (> 3.1)
       railties (> 3.1)
+    rails_semantic_logger (4.17.0)
+      rack
+      railties (>= 5.1)
+      semantic_logger (~> 4.16)
     railties (6.1.7.10)
       actionpack (= 6.1.7.10)
       activesupport (= 6.1.7.10)
@@ -963,6 +967,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    semantic_logger (4.16.1)
+      concurrent-ruby (~> 1.0)
     shacl (0.4.1)
       json-ld (~> 3.3)
       rdf (~> 3.3)
@@ -1169,6 +1175,7 @@ DEPENDENCIES
   pg (~> 1.3)
   puma
   rails (~> 6.1)
+  rails_semantic_logger
   redcarpet
   riiif (~> 2.1)
   rsolr (>= 1.0, < 3)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,4 +19,11 @@ class ApplicationController < ActionController::Base
     params.delete('locale')
     render template: 'pages/not_acceptable', status: :not_acceptable
   end
+
+  private
+
+  def append_info_to_payload(payload)
+    super
+    payload[:request_id] = request.request_id
+  end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationJob < ActiveJob::Base
+  def perform_now
+    SemanticLogger.tagged(job_class: self.class, job_id: job_id) { super }
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,9 @@ module Cypripedium
       config.bag_prefix = 'mpls_fed_research'
       config.bag_path = ENV['BAG_PATH'] || Rails.root.join('tmp', 'bags')
     end
+
+    # Output logs in JSON format
+    config.rails_semantic_logger.format = :json
+    config.semantic_logger.application = Rails.application.class.module_parent_name
   end
 end


### PR DESCRIPTION
In order to easily use search and filtering capabilities in log aggregation and analysis tools like AWS CloudWatch logs, we want to send our logs in an easily parsable format.

We've chosen [Semantic Logger](https://logger.rocketjob.io/index.html) because it provides an easy drop-in replacement for the default Rails logger. Semantic Logger doesn't require us to change any of our existing logging code and makes it simple to output logs in JSON format.