### PR TITLE
Ensure we honor deprecation silencing within our local app

### DIFF
--- a/app/patches/extensions/deprecation_reporting.rb
+++ b/app/patches/extensions/deprecation_reporting.rb
@@ -11,6 +11,8 @@ module Extensions
     def self.included(k)
       k.class_eval do
         def self.warn(*args)
+          return if Rails.application.config.active_support.deprecation == :silence
+
           if args[0].is_a?(String)
             message, callstack = args[0..1]
           else


### PR DESCRIPTION
We previously patched deprecation reporting behavior to remove and obsolete dependency; however, we need to update that code to honor deprecaton silencing if it exists in the configuration.