### PR TITLE
Elimiate slow search defaults

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -27,7 +27,7 @@ class CatalogController < ApplicationController
 
     config.show.tile_source_field = :content_metadata_image_iiif_info_ssm
     config.show.partials.insert(1, :openseadragon)
-    config.search_builder_class = Hyrax::CatalogSearchBuilder
+    config.search_builder_class = CypripediumSearchBuilder
 
     config.add_results_collection_tool(:sort_widget)
     config.add_results_collection_tool(:per_page_widget)

--- a/app/models/cypripedium_search_builder.rb
+++ b/app/models/cypripedium_search_builder.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+class CypripediumSearchBuilder < Hyrax::CatalogSearchBuilder
+  # Hyrax adds a default collection facet filter that significantly increases
+  # the time Solr takes to process catalog requests.
+
+  # Cypripedium does not display a collection facet, so we want to remove this
+  # filter from the processor chain used in the CatalogController
+  default_processor_chain.delete(:filter_collection_facet_for_access)
+  default_processor_chain.delete(:show_works_or_works_that_contain_files)
+  default_processor_chain.delete(:add_query_to_solr)
+  default_processor_chain.delete(:show_only_active_records)
+  default_processor_chain.uniq!
+end


### PR DESCRIPTION
**ISSUE**
Hyrax adds default search filters to prevent restricted collections from appearing in facet lists and to show works in searches that have files with metadata that matches search criteria. Both of these significantly increase the Solr search time.

**CHANGE**
Neither use case exists in the FRBM application, so we have created a custom search builder that removes these expensive queries from the default processor chain.