### PR TITLE
Disable deprecations warnings in production logs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,8 +74,8 @@ Rails.application.configure do
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
-  # Send deprecation notices to registered listeners.
-  config.active_support.deprecation = :notify
+  # Do not send deprecation notices to registered listeners.
+  config.active_support.deprecation = :silence
 
   # Log disallowed deprecations.
   config.active_support.disallowed_deprecation = :log


### PR DESCRIPTION
**ISSUE**
Logs in the production environment are getting swamped by deprecation warnings from Hyrax and Blacklight dependencies. So many warnings are being generated that there is a measurable performance degredation when processing web requests to the application.

**RESOLUTION**
Silence deprecation warnings in production environments. Deprecation warnings will still appear in development and test environments.