### PR TITLE
Set loglevel = INFO in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :error
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
**ISSUE**
We want to be able to trace request processing from apache through Rails. To do so, we need to see the requests that Rails is handling. We can do this automatically at the INFO log level.