### PR TITLE
Remove deprecated bundler flag

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -9,7 +9,6 @@ set :deploy_to, '/opt/cypripedium'
 set :ssh_options, keys: ["cypripedium-cd-deploy"] if File.exist?("cypripedium-cd-deploy")
 
 set :log_level, :error
-set :bundle_flags, '--deployment'
 set :bundle_env_variables, nokogiri_use_system_libraries: 1
 
 # Sidekiq configuration on servers


### PR DESCRIPTION
**ISSUE**
Deployments are displaying the following warning:
```
00:12 bundler:install
      01 bundle install --jobs 4 --deployment
      01 [DEPRECATED] The `--deployment` flag is deprecated because it relies on being remembered across bundler invocations, whi…
```

**RESOULUTION**
Remove the legacy deployment flag; Capistrano has added a separate task to configure the deployment setting correctly:
```
00:06 bundler:config
      01 bundle config --local deployment true
    ✔ 01 deploy@i-03eccda0ad97c6c74 0.314s
```