### PR TITLE
[FIX] Restore required search filter

### DIFF
--- a/app/models/cypripedium_search_builder.rb
+++ b/app/models/cypripedium_search_builder.rb
@@ -7,7 +7,6 @@ class CypripediumSearchBuilder < Hyrax::CatalogSearchBuilder
   # filter from the processor chain used in the CatalogController
   default_processor_chain.delete(:filter_collection_facet_for_access)
   default_processor_chain.delete(:show_works_or_works_that_contain_files)
-  default_processor_chain.delete(:add_query_to_solr)
   default_processor_chain.delete(:show_only_active_records)
   default_processor_chain.uniq!
 end


### PR DESCRIPTION
**ISSUE**
All searches were returning the same results, regardless of what search terms were entered.

**DIAGNOSIS**
The analysis of which search filters were unnecessary or redundant incorrectly identified the search filter that adds search box text to the Solr request.

**RESOLUTION**
Restore the erroneously deleted filter - i.e. don't delete it in our customized search builder.