### PR TITLE
Remove Turobolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,6 @@ gem 'solrizer'
 gem 'strscan', '1.0.3' # match version installed on server as system gem
 gem 'terser'
 gem 'tether-rails'
-gem 'turbolinks', '~> 5'
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1064,9 +1064,6 @@ GEM
     tinymce-rails (5.10.9)
       railties (>= 3.1.1)
     trailblazer-option (0.1.2)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     twitter-typeahead-rails (0.11.1.pre.corejavascript)
       actionpack (>= 3.1)
       jquery-rails
@@ -1190,7 +1187,6 @@ DEPENDENCIES
   strscan (= 1.0.3)
   terser
   tether-rails
-  turbolinks (~> 5)
   twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,7 +14,6 @@
 //= require tether
 //= require activestorage
 //= require rails-ujs
-//= require turbolinks
 //= require jquery3
 //= require popper
 //= require twitter/typeahead

--- a/app/assets/javascripts/notification-sort.js
+++ b/app/assets/javascripts/notification-sort.js
@@ -1,5 +1,0 @@
-$(document).on('turbolinks:load', function() {
-  if ($('h1').text() === '  Notifications') {
-    $('table').DataTable().order([0, 'desc']).draw()
-  }
-})

--- a/app/jobs/bag_job.rb
+++ b/app/jobs/bag_job.rb
@@ -42,7 +42,7 @@ class BagJob < ApplicationJob
       <div>
         Your bag containing #{work_count} #{'work'.pluralize(work_count)},
         including #{bag_files.first}, is available for download at
-        <a data-turbolinks='false' href='/bag/#{bag_file_name}.#{bag_format}'>#{bag_file_name}.#{bag_format}</a>
+        <a href='/bag/#{bag_file_name}.#{bag_format}'>#{bag_file_name}.#{bag_format}</a>
       </div>
     NOTICE
   end

--- a/app/views/hyrax/my/works/_batch_actions.html.erb
+++ b/app/views/hyrax/my/works/_batch_actions.html.erb
@@ -1,9 +1,9 @@
 <div class="batch-info">
   <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>
 
-  <div class="batch-toggle" data-turbolinks="false">
-    <%= button_tag "Add to Zip Bag", data: {turbolinks: false}, class: 'btn btn-primary e submits-batches submits-ids-for-zip-bag' %>
-    <%= button_tag "Add to Tar Bag", data: {turbolinks: false}, class: 'btn btn-primary submits-batches submits-ids-for-tar-bag' %>
+  <div class="batch-toggle">
+    <%= button_tag "Add to Zip Bag", class: 'btn btn-primary e submits-batches submits-ids-for-zip-bag' %>
+    <%= button_tag "Add to Tar Bag", class: 'btn btn-primary submits-batches submits-ids-for-tar-bag' %>
 
 
     <% session[:batch_edit_state] = "on" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,8 +4,8 @@
     <title>Research Database | Federal Reserve Bank of Minneapolis</title>
     <%= csrf_meta_tags %>
 
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag    'application', media: 'all' %>
+    <%= javascript_include_tag 'application' %>
   </head>
 
   <body>

--- a/spec/system/bag_export_spec.rb
+++ b/spec/system/bag_export_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe 'Bagit export:', type: :system, js: true do
     xit 'queues the bagit job' do
       visit Hyrax::Engine.routes.url_helpers.my_works_path
 
-      # Click 'All Works' tab to trigger turbolinks
       click_on 'All Works'
       expect(page).to have_link(publication.title.first)
       expect(page).to have_link(data_set.title.first)


### PR DESCRIPTION
**RATIONALE**
Turbolinks are creating a variety of timing issues in system tests.

Turbolinks [has been deprecated for over 4 years](https://github.com/turbolinks/turbolinks?tab=readme-ov-file#turbolinks-is-no-longer-under-active-development), so we're removing it and will implement Turbo if the need arises.