### PR TITLE
Ensure the application uses the AF FileSet model

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -262,6 +262,10 @@ Hyrax.config do |config|
   # Identify the indexer that will be used for Admin Sets
   # config.administrative_set_indexer = Hyrax::Indexers::AdministrativeSetIndexer
 
+  # Identify the model class name that will be used for File Sets in your app
+  # (i.e. FileSet for ActiveFedora, Hyrax::FileSet for Valkyrie)
+  config.file_set_model = '::FileSet'
+
   # Identify the form that will be used for File Sets
   # config.file_set_form = Hyrax::Forms::FileSetForm
 


### PR DESCRIPTION
**ISSUE**
The Hyrax 5.x upgrade changed the default for fileset to the valkyrie-based `Hyrax::FileSet` model instead of the active-fedora `FileSet` model. This broke a variety of functions on existing FileSets.

**RESOLTUION**
This change should ensure the application uses the `FileSet` model consistently throughout the codebase.