### PR TITLE
Fix enum deprecation warning

### DIFF
--- a/app/models/work_zip.rb
+++ b/app/models/work_zip.rb
@@ -14,7 +14,7 @@
 
 class WorkZip < ApplicationRecord
   # rubocop:disable Layout/HashAlignment
-  enum status: {
+  enum :status, {
     unavailable:  0,
     queued:       1,
     working:      2,


### PR DESCRIPTION
**DEPRECATION WARNING:** Defining enums with keyword arguments is deprecated and will be removed in Rails 8.0. Positional arguments should be used instead:

```
enum :status, {:unavailable=>0, :queued=>1, :working=>2, :failed=>3, :completed=>4}
```