### PR TITLE
Fix fixture path deprecation

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,7 +36,7 @@ require 'support/factory_bot'
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_paths = [Rails.root.join('spec', 'fixtures')]
 
   config.use_transactional_fixtures = false
 


### PR DESCRIPTION
**Deprecation Warnings:** Rails 7.1 has deprecated the singular fixture_path in favour of an array. You should migrate to plural.