### PR TITLE
Ensure credentials are shared across deployments

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -30,7 +30,7 @@ append :linked_dirs, "log"
 append :linked_dirs, "public/assets"
 
 append :linked_files, "config/database.yml"
-append :linked_files, "config/secrets.yml"
+append :linked_files, "config/master.key"
 append :linked_files, ".env.production"
 
 # after 'deploy:published', 'hyrax:ensure_default_admin_set'


### PR DESCRIPTION
We want Capstrano to treat `./config/master.key` as a shared file so it persists across deployments.

With this strategy, the `master.key` file must be installed out of band from the deployment process, but should not need to be updated unless we choose to re-encode the credentials with a new key in the future.