### PR TITLE
Stop using posix-spawn for mini_magick

### DIFF
--- a/config/initializers/mini_magick.rb
+++ b/config/initializers/mini_magick.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require 'mini_magick'
-
-MiniMagick.configure do |config|
-  config.shell_api = "posix-spawn"
-end


### PR DESCRIPTION
The posix-spawn functionality has been obsolete for some time, see
* https://github.com/minimagick/minimagick/pull/558
* https://github.com/minimagick/minimagick/releases/tag/v4.13.0

This change removes the initializer that enables posix-spawn, since it's use is not compatible with Ruby 3.x+