### PR TITLE
Set copyright year when application starts

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -7,7 +7,7 @@
     </div>
     <div class="navbar-right">
       <div class="navbar-text text-right">
-        <p><%= t('hyrax.footer.copyright_html') %></p>
+        <p><%= t('hyrax.footer.copyright_html', year: Cypripedium::COPYRIGHT_YEAR ) %></p>
         <p><%= t('hyrax.background_attribution_html') %></p>
         <p><%= t('hyrax.product_name') %> <span title="<%= ReleaseInfo.sha %>"><%= ReleaseInfo.branch %> updated <%= ReleaseInfo.deployment_timestamp %></span></p>
         <p>built using Hyrax v<%= Hyrax::VERSION %></p>

--- a/config/initializers/copyright_year.rb
+++ b/config/initializers/copyright_year.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Set the copyright year displayed in the page footer anytime we restart the application
+Cypripedium::COPYRIGHT_YEAR = Time.current.year.to_s

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -52,7 +52,7 @@ de:
     directory:
       suffix: "@ Example.org"
     footer:
-      copyright_html: "<strong>Copyright &copy; 2018 Federal Reserve Bank of Minneapolis</strong>"
+      copyright_html: "<strong>Copyright &copy; %{year} Federal Reserve Bank of Minneapolis</strong>"
       service_html: Ein Dienst von <a href="https://research.minneapolisfed.org" class="navbar-link">Federal Reserve Bank of Minneapolis Research Division</a>.
     institution_name: Federal Reserve Bank of Minneapolis
     institution_name_full: Federal Reserve Bank of Minneapolis Research Division

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -112,7 +112,7 @@ en:
     directory:
       suffix:               "@example.org"
     footer:
-      copyright_html: "<strong>Copyright &copy; 2022 Federal Reserve Bank of Minneapolis</strong>"
+      copyright_html: "<strong>Copyright &copy; %{year} Federal Reserve Bank of Minneapolis</strong>"
       service_html: A service of the <a href="https://www.minneapolisfed.org/economic-research" class="navbar-link">Federal Reserve Bank of Minneapolis Research Division</a>.
   creators:
     table_headers:

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -52,7 +52,7 @@ es:
     directory:
       suffix: "@example.org"
     footer:
-      copyright_html: "<strong>Copyright &copy; 2018  &copy; 2018 Federal Reserve Bank of Minneapolis</strong>"
+      copyright_html: "<strong>Copyright &copy; %{year} Federal Reserve Bank of Minneapolis</strong>"
       service_html: Un servicio de <a href="https://research.minneapolisfed.org" class="navbar-link">Federal Reserve Bank of Minneapolis Research Division</a>.
     institution_name: Federal Reserve Bank of Minneapolis
     institution_name_full: Federal Reserve Bank of Minneapolis Research Division

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -52,7 +52,7 @@ fr:
     directory:
       suffix: "@ Example.org"
     footer:
-      copyright_html: "<strong>Copyright &copy; 2018 Federal Reserve Bank of Minneapolis/strong>"
+      copyright_html: "<strong>Copyright &copy; %{year} Federal Reserve Bank of Minneapolis/strong>"
       service_html: Un service de <a href="https://research.minneapolisfed.org" class="navbar-link">Federal Reserve Bank of Minneapolis Research Division</a>.
     institution_name: Federal Reserve Bank of Minneapolis
     institution_name_full: Federal Reserve Bank of Minneapolis Research Division

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -52,7 +52,7 @@ it:
     directory:
       suffix: "@ example.org"
     footer:
-      copyright_html: "<strong>Copyright &copy; 2018 Federal Reserve Bank of Minneapolis</strong>"
+      copyright_html: "<strong>Copyright &copy; %{year} Federal Reserve Bank of Minneapolis</strong>"
       service_html: Un servizio di <a href="https://research.minneapolisfed.org" class="navbar-link">Federal Reserve Bank of Minneapolis Research Division</a>.
     institution_name: Federal Reserve Bank of Minneapolis
     institution_name_full: Federal Reserve Bank of Minneapolis Research Division

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -52,7 +52,7 @@ pt-BR:
     directory:
       suffix: "@ Example.org"
     footer:
-      copyright_html: "<strong>Copyright © 2018 Federal Reserve Bank of Minneapolis</strong>"
+      copyright_html: "<strong>Copyright &copy; %{year} Federal Reserve Bank of Minneapolis</strong>"
       service_html: Um serviço de <a href="https://research.minneapolisfed.org" class="navbar-link">Federal Reserve Bank of Minneapolis Research Division</a>.
     institution_name: Federal Reserve Bank of Minneapolis
     institution_name_full: Federal Resesrve Bank of Minneapolis Research Division

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -52,7 +52,7 @@ zh:
     directory:
       suffix: "@example.org"
     footer:
-      copyright_html: "<strong>版权所有 &copy; 2018 Federal Reserve Bank of Minneapolis</strong>"
+      copyright_html: "<strong>版权所有 &copy; %{year} Federal Reserve Bank of Minneapolis</strong>"
       service_html: 的服务<a href="https://research.minneapolisfed.org" class="navbar-link">Federal Reserve Bank of Minneapolis Research Division</a>.
     institution_name: Federal Reserve Bank of Minneapolis
     institution_name_full: Federal Reserve Bank of Minneapolis


### PR DESCRIPTION
**ISSUE**
The copyright displayed in the application footer was out-of-date and displayed different years depending on the language.

**DIAGNOSIS**
The copright year was being set in the individual translation files and not being updated consistently.

**RESOLUTION**
This change sets a global constant once when the application starts and uses that constant to populate the copyright year value for all internationalization strings.