### PR TITLE
Clean up sample citation styling

### DIFF
--- a/app/assets/stylesheets/citations.scss
+++ b/app/assets/stylesheets/citations.scss
@@ -1,5 +1,10 @@
-.citation-header h3 {
-  line-height: 1rem;
+.modal-header.citation-header {
+  display: block;
+
+  .show-header {
+    line-height: 1.75rem;
+    font-size: large;
+  }
 }
 
 .chicago-citation, .mla-citation, .apa-citation {

--- a/app/views/hyrax/citations/work.html.erb
+++ b/app/views/hyrax/citations/work.html.erb
@@ -4,7 +4,7 @@
   </button>
 
   <h3 class="modal-title show-header">
-    <small><span class="text-muted"><%= t('hyrax.base.citations.header') %></span></small>
+    <span class="text-muted"><%= t('hyrax.base.citations.header') %></span>
   </h3>
 
   <span><em><%= t('hyrax.base.citations.disclaimer') %></em></span>


### PR DESCRIPTION
**ISSUE**
The display style changed from block in Hyrax 3 to flex-box in Hyrax 5. Text layout in the citation header seemed less clean.

**RESOLUTION**
Explicitly set the display style back to block.

**BEFORE**
<img width="807" alt="image" src="https://github.com/user-attachments/assets/91412707-c316-4068-abe2-7a8a84b35760" />


**AFTER**
<img width="802" alt="image" src="https://github.com/user-attachments/assets/f83bbf7e-cdbd-4562-889a-e64ce91b9412" />

