### PR TITLE
Fix handling of non-parseable creation dates

### DIFF
--- a/app/presenters/cypripedium/citation_formatter.rb
+++ b/app/presenters/cypripedium/citation_formatter.rb
@@ -104,10 +104,12 @@ module Cypripedium
     # e.g. 2021-01-12  --> January 2021
     #      2019 Winter --> Winter 2019
     #      1968        --> 1968
+    #      19xx        --> deposit year
+    #      Nineteen Ten -> deposit year (i.e. we don't handle non-numeric dates)
     def date_for_citation
-      return solr_document.date_uploaded&.year || 'no date' if date_created.blank?
+      elements = date_created&.first&.match(/(?<year>\d{4})(-(?<month>\d{2})(-(?<day>\d{2}))?|\s*(?<season>[[:alpha:]]+))?/)
+      return solr_document.date_uploaded&.year || 'no date' if elements.blank?
 
-      elements = date_created.first.match(/(?<year>\d{4})(-(?<month>\d{2})(-(?<day>\d{2}))?|\s*(?<season>[[:alpha:]]+))?/)
       return [elements[:season], elements[:year]].join(' ') if elements[:season]
       return [Date::MONTHNAMES[elements[:month].to_i], elements[:year]].join(' ') if elements[:month]
       elements[:year]

--- a/spec/presenters/cypripedium/citation_formatter_spec.rb
+++ b/spec/presenters/cypripedium/citation_formatter_spec.rb
@@ -57,6 +57,12 @@ RSpec.describe Cypripedium::CitationFormatter do
       expect(citation).to include('no date')
     end
 
+    it 'uses the upload year if "date created" can not be parsed' do
+      solr_data[:date_created_tesim] = '19xx'
+      solr_data[:date_uploaded_dtsi] = '1995-07-10T11:23:45Z'
+      expect(citation).to include('1995')
+    end
+
     it 'provides the direct link if DOI does not exist' do
       solr_data.delete(:identifier_tesim)
       expect(citation).to include 'https://researchdatabase.minneapolisfed.org/concern/publications/br86b3634'


### PR DESCRIPTION
**ISSUE**
Some works were not displaying because the citation presenter code was encountering unexpected values that could not successfully be parsed. Unexpected date values resulted in an unhandled exceptions instead of having graceful failure modes.

**RESOLUTION**
Add a test case reprensenting the data we saw in the live application and refactor the code to handle unexpected values gracefully: In this case, we use the deposit year if the creation date is missing or can not be parsed.