### PR TITLE
Visually distinguish Creators without group assignments

### DIFF
--- a/app/assets/stylesheets/creators.scss
+++ b/app/assets/stylesheets/creators.scss
@@ -36,9 +36,8 @@
         content: "☑️️";
       }
     }
-    td.display_name a::before {
-      content: "✏️";
-      margin-right: 0.5rem;
+    td.group.unassigned {
+      color: lightgray;
     }
   }
 }

--- a/app/views/creators/_creator_listing.html.erb
+++ b/app/views/creators/_creator_listing.html.erb
@@ -14,13 +14,12 @@
   </thead>
   <tbody>
       <% @creators.map do |creator| %>
-        <tr id="<%= dom_id(creator) -%>" >
-<!--          <td class="id"><%#= creator.id %></td>-->
+        <tr id="<%= dom_id(creator) -%>">
           <td class="active_creator">
             <span class="visually-hidden"><%= creator.active_creator.to_s -%></span>
             <span class="aria-hidden active-<%= creator.active_creator.to_s -%>"></span>
           </td>
-          <td class="group"><%= creator.group -%></td>
+          <td class="group <%= creator.group -%>"><%= creator.group -%></td>
           <% if current_or_guest_user.can?(:edit, Creator) %>
             <td class="edit"><%= link_to 'Edit', edit_creator_path(creator) -%></td>
           <% end %>
@@ -28,7 +27,6 @@
           <td class="repec"><%= creator.repec -%></td>
           <td class="viaf"><%= creator.viaf -%></td>
           <td class="alternate_names"><%= creator.alternate_names.join(" ; ") -%></td>
-<!--          <td><%#= link_to 'Show', creator -%></td>-->
         </tr>
       <% end %>
   </tbody>


### PR DESCRIPTION
This change helps visally distinguish creators that haven't been assigned a group yet - e.g. group = 'unassigned' by displaying the group name in a light gray on the index page.

**BEFORE**
<img width="1224" height="376" alt="image" src="https://github.com/user-attachments/assets/43d9d78d-3b39-4d37-8388-d0f325fda926" />

**AFTER**
<img width="1237" height="369" alt="image" src="https://github.com/user-attachments/assets/7bf85064-ef5f-42f1-8472-3d58485a9530" />
