### PR TITLE
Allow administrators to edit creator group assignments

### DIFF
--- a/app/assets/stylesheets/creators.scss
+++ b/app/assets/stylesheets/creators.scss
@@ -41,3 +41,41 @@
     }
   }
 }
+
+form.new_creator, form.edit_creator {
+  width: 45rem;
+  .has-error {
+    input, select {
+      border-color: red;
+    }
+    .help-block {
+      margin-left: 0.5rem;
+      color: red;
+    }
+    h2 {
+      color: red;
+      font-size: 1.75rem;
+    }
+  }
+
+  .multi_value {
+    .field-controls {
+      margin-left: auto;
+    }
+    .listing {
+      max-width: 100%;
+
+      li:first-of-type {
+        width: 100%;
+      }
+    }
+  }
+
+  input[type=checkbox] {
+    margin-right: 0.5rem;
+  }
+
+  input[type=submit] {
+    margin-bottom: 1rem;
+  }
+}

--- a/app/controllers/creators_controller.rb
+++ b/app/controllers/creators_controller.rb
@@ -3,7 +3,7 @@ class CreatorsController < ApplicationController
   include Hydra::Controller::ControllerBehavior
   load_and_authorize_resource
   before_action :set_creator, only: [:show, :edit, :update, :destroy]
-  # before_action :pick_theme
+  before_action :set_breadcrumbs
   with_themed_layout :pick_layout
 
   def pick_layout
@@ -13,32 +13,18 @@ class CreatorsController < ApplicationController
   # GET /creators
   # GET /creators.json
   def index
-    add_breadcrumb t(:'hyrax.controls.home'), root_path
-    add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path if current_user&.admin?
-    add_breadcrumb t(:'hyrax.creators.index.manage_creators')
     @creators = Creator.all.order(:display_name)
   end
 
   # GET /creators/1
   # GET /creators/1.json
-  def show
-    add_breadcrumb t(:'hyrax.controls.home'), root_path
-    add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path if current_user&.admin?
-    add_breadcrumb t(:'hyrax.creators.index.manage_creators'), '#'
-  end
+  def show; end
 
   # GET /creators/new
-  def new
-    @creator = Creator.new
-  end
+  def new; end
 
   # GET /creators/1/edit
-  def edit
-    add_breadcrumb t(:'hyrax.controls.home'), root_path
-    add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path if current_user&.admin?
-    add_breadcrumb t(:'hyrax.creators.index.manage_creators'), creators_path
-    add_breadcrumb "Edit Creator", '#'
-  end
+  def edit; end
 
   # POST /creators
   # POST /creators.json
@@ -50,7 +36,7 @@ class CreatorsController < ApplicationController
         format.html { redirect_to @creator, notice: 'Creator was successfully created.' }
         format.json { render :show, status: :created, location: @creator }
       else
-        format.html { render :new }
+        format.html { render :new, status: :unprocessable_entity }
         format.json { render json: @creator.errors, status: :unprocessable_entity }
       end
     end
@@ -64,7 +50,7 @@ class CreatorsController < ApplicationController
         format.html { redirect_to @creator, notice: 'Creator was successfully updated.' }
         format.json { render :show, status: :ok, location: @creator }
       else
-        format.html { render :edit }
+        format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @creator.errors, status: :unprocessable_entity }
       end
     end
@@ -82,12 +68,21 @@ class CreatorsController < ApplicationController
   # remove empty strings from alternate_names array
   def creator_params
     new_params = safe_params
-    new_params["alternate_names"].compact_blank!
+    new_params["alternate_names"]&.compact_blank!
     new_params
   end
 
   # Only allow a list of trusted parameters through.
   def safe_params
-    params.require(:creator).permit(:display_name, { alternate_names: [] }, :repec, :viaf, :active_creator)
+    params.require(:creator).permit(:display_name, { alternate_names: [] }, :group, :repec, :viaf, :active_creator)
+  end
+
+  # Set breadcrumbs - e.g. / Home / Dashboard / Manage Creators / ...
+  def set_breadcrumbs
+    add_breadcrumb t(:'hyrax.controls.home'), root_path
+    add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path if current_user&.admin?
+    add_breadcrumb t(:'hyrax.creators.index.manage_creators'), creators_path
+    add_breadcrumb @creator&.display_name if [:show, :edit, :update].include?(action_name.to_sym)
+    add_breadcrumb "New Creator" if [:new, :create].include?(action_name.to_sym)
   end
 end

--- a/app/models/creator.rb
+++ b/app/models/creator.rb
@@ -5,7 +5,7 @@ class Creator < ApplicationRecord
   serialize :alternate_names, type: Array
   after_save :reindex_setup
 
-  enum :group, { unassigned: 0, staff: 1, consultant: 2 }, default: :unassigned
+  enum :group, { unassigned: 0, staff: 1, consultant: 2 }, default: :unassigned, validate: true
 
   def reindex_setup
     CreatorReindexJob.perform_later self

--- a/app/views/creators/_creator.json.jbuilder
+++ b/app/views/creators/_creator.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
-json.extract! creator, :id, :display_name, :alternate_names, :repec, :viaf, :active_creator, :created_at, :updated_at
+json.extract! creator, :id, :display_name, :alternate_names, :group, :repec, :viaf, :active_creator, :created_at, :updated_at
 json.url creator_url(creator, format: :json)

--- a/app/views/creators/_form.html.erb
+++ b/app/views/creators/_form.html.erb
@@ -1,8 +1,15 @@
 <%= simple_form_for @creator do |f| %>
+  <% if creator.errors.any? %>
+    <div class="has-error">
+      <h2>Please correct the <%= pluralize(creator.errors.count, "error") %> below before saving.</h2>
+    </div>
+  <% end %>
+
   <%= f.input :display_name %>
   <%= f.input :alternate_names, as: :multi_value %>
+  <%= f.input :group, collection: Creator.groups.keys, include_blank: false %>
   <%= f.input :repec %>
   <%= f.input :viaf %>
   <%= f.input :active_creator, as: :boolean %>
-  <%= f.button :submit %>
+  <%= f.button :submit, class: 'btn btn-primary text-white' %>
 <% end %>

--- a/app/views/creators/edit.html.erb
+++ b/app/views/creators/edit.html.erb
@@ -1,4 +1,6 @@
-<h1>Editing Creator</h1>
+<% provide :page_header do %>
+  <h1><span class="fa fa-address-card" aria-hidden="true"></span> <%= t(:'hyrax.creators.edit') %></h1>
+<% end %>
 
 <%= render 'form', creator: @creator %>
 

--- a/spec/models/creator_spec.rb
+++ b/spec/models/creator_spec.rb
@@ -35,10 +35,9 @@ RSpec.describe Creator, type: :model do
     end
 
     it "rejects invalid values" do
-      creator = FactoryBot.build(:creator)
-      expect {
-        creator.group = 'chaotic-good'
-      }.to raise_error(ArgumentError, /'chaotic-good' is not a valid group/)
+      creator = FactoryBot.build(:creator, group: 'chaotic-good')
+      expect(creator).to be_invalid
+      expect(creator.errors[:group]).to include "is not included in the list"
     end
   end
 

--- a/spec/views/creators/edit.html.erb_spec.rb
+++ b/spec/views/creators/edit.html.erb_spec.rb
@@ -2,26 +2,46 @@
 require 'rails_helper'
 
 RSpec.describe "creators/edit", type: :view do
+  let(:creator) { FactoryBot.build(:creator, id: 1) }
+
   before do
-    @creator = assign(:creator, Creator.create!(
-      display_name: "MyString",
-      alternate_names: "MyString",
-      repec: "MyString",
-      viaf: "MyString"
-    ))
+    allow(creator).to receive(:persisted?).and_return(true)
+    assign(:creator, creator)
   end
 
-  skip "renders the edit creator form" do
+  it 'renders the edit creator form', :aggregate_failures do
     render
+    expect(rendered).to have_field('creator_display_name',    name: 'creator[display_name]')
+    expect(rendered).to have_field('creator_alternate_names', name: 'creator[alternate_names][]')
+    expect(rendered).to have_field('creator_group',           name: 'creator[group]')
+    expect(rendered).to have_field('creator_repec',           name: 'creator[repec]')
+    expect(rendered).to have_field('creator_viaf',            name: 'creator[viaf]')
+    expect(rendered).to have_field('creator_active_creator',  name: 'creator[active_creator]')
 
-    assert_select "form[action=?][method=?]", creator_path(@creator), "post" do
-      assert_select "input[name=?]", "creator[display_name]"
+    expect(rendered).to have_selector("form[@action='#{creator_path(creator)}']")
+  end
 
-      assert_select "input[name=?]", "creator[alternate_names]"
+  it 'restricts groups to those provided by the Creator class' do
+    render
+    expect(rendered).to have_select('creator_group', options: ["unassigned", "staff", "consultant"])
+  end
 
-      assert_select "input[name=?]", "creator[repec]"
+  context 'with validation errors' do
+    let(:creator) { FactoryBot.build(:creator, id: 1, display_name: '', group: 'lawful-evil') }
 
-      assert_select "input[name=?]", "creator[viaf]"
+    before do
+      creator.validate
+    end
+
+    it 'displays a top-level error message' do
+      render
+      expect(rendered).to have_selector('.has-error', text: 'Please correct the 2 errors below before saving.')
+    end
+
+    it 'tags invalid fields with error-classes', :aggregate_failures do
+      render
+      expect(rendered).to have_selector('.creator_display_name.has-error', text: "can't be blank")
+      expect(rendered).to have_selector('.creator_group.has-error', text: 'is not included in the list')
     end
   end
 end


### PR DESCRIPTION
This change
* Updates the creator edit form allow choosing a valid group
* Cleans up form display
* Updates the CreatorController to accept group values
* Ensures that breadcrumbs are displayed when there are errors on the new or edit forms
* Indicates validation errors on the edit form
* Adds tests for the views and breadcrumbs
* Updates pending creator request spect to test invalid input

**BEFORE**
<img width="1658" height="567" alt="image" src="https://github.com/user-attachments/assets/3b4018c4-5b49-49ad-b057-01f35e1b66c5" />

**AFTER**
<img width="1654" height="759" alt="image" src="https://github.com/user-attachments/assets/e8c0ce8a-514d-4d54-a55c-2a1eec1d8f57" />
