### PR TITLE
Clean up Creator show view

### DIFF
--- a/app/assets/stylesheets/creators.scss
+++ b/app/assets/stylesheets/creators.scss
@@ -7,11 +7,31 @@
     .alternate_names { width: auto; }
     .repec { width: 6rem; }
     .viaf { width: 22rem; }
+
+    &.creators-show.table td.attribute_value {
+      text-align: left;
+    }
   }
 
   .table th, .table td {
     padding: 0.25rem;
     padding-bottom: 0.5rem;
+
+    &.attribute_name {
+      width: 9.5rem;
+      text-align: right;
+      padding-right: 1rem;
+    }
+
+    &.attribute_value {
+      text-align: left;
+      width: auto;
+      font-weight: bold;
+    }
+
+    ul.tabular {
+      padding-left: 0;
+    }
   }
 
   a.btn.new_creator {
@@ -24,7 +44,7 @@
   }
 
   tbody {
-    td.active_creator {
+    td.active_creator, tr.active_creator td.attribute_value {
       font-size: 0;
       text-align: center;
       .active-true::before {

--- a/app/views/creators/_creator_listing.html.erb
+++ b/app/views/creators/_creator_listing.html.erb
@@ -1,15 +1,15 @@
 <table class="creators table">
   <thead>
     <tr>
-      <th class="active_creator"><%= t('.active') -%></th>
-      <th class="group"><%= t('.group') -%></th>
+      <th class="active_creator"><%= t('creators.active_creator') -%></th>
+      <th class="group"><%= t('creators.group') -%></th>
       <% if current_or_guest_user.can?(:edit, Creator) %>
         <th class="edit"></th>
       <% end %>
-      <th class="display_name"><%= t('.display_name') -%></th>
-      <th class="repec"><%= t('.repec') -%></th>
-      <th class="viaf"><%= t('.viaf') -%></th>
-      <th class="alternate_names"><%= t('.alternate_names') -%></th>
+      <th class="display_name"><%= t('creators.display_name') -%></th>
+      <th class="repec"><%= t('creators.repec') -%></th>
+      <th class="viaf"><%= t('creators.viaf') -%></th>
+      <th class="alternate_names"><%= t('creators.alternate_names') -%></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/creators/show.html.erb
+++ b/app/views/creators/show.html.erb
@@ -1,35 +1,53 @@
-<p id="notice"><%= notice %></p>
-<div class="col-xd-12">
-  <h1>Show Creator</h1>
-</div>
-<div class="col-sm-8">
-  <label class="control-label string" for="creator_display_name">Display name</label>
-  <ul class="tabular">
-    <li class="attribute"><%= @creator.display_name %>
-    </li>
-  </ul>
+<% provide :page_header do %>
+  <h1><span class="fa fa-address-card" aria-hidden="true"></span> <%= t('creators.creator') %></h1>
+<% end %>
 
-  <label class="control-label string" for="creator_alternate_names">Alternate names</label>
-  <ul class="tabular">
-    <% @creator.alternate_names.each do |name| %>
-        <li class="attribute"><%= name %></li>
-    <% end %>
-  </ul>
+<div id="creators">
+  <table class="creators-show table table-borderless">
+    <tbody>
+    <tr class="display_name">
+      <td class="attribute_name"><%= t('creators.display_name') -%></td>
+      <td class="attribute_value"><%= @creator.display_name -%></td>
+    </tr>
 
-  <label class="control-label string" for="creator_repec">RePEc</label>
-  <ul class="tabular">
-    <li class="attribute"><%= @creator.repec %></li>
-  </ul>
+    <tr class="active_creator">
+      <td class="attribute_name"><%= t('creators.active_creator') -%></td>
+      <td class="attribute_value">
+        <span class="visually-hidden"><%= @creator.active_creator.to_s -%></span>
+        <span class="aria-hidden active-<%= @creator.active_creator.to_s -%>"></span>
+      </td>
+    </tr>
 
-  <label class="control-label string" for="creator_viaf">VIAF</label>
-  <ul class="tabular">
-    <li class="attribute"><%= @creator.viaf %></li>
-  </ul>
+    <tr class="group">
+      <td class="attribute_name"><%= t('creators.group') -%></td>
+      <td class="attribute_value group <%= @creator.group -%>"><%= @creator.group -%></td>
+    </tr>
 
-  <label class="control-label string" for="creator_active">Active</label>
-  <ul class="tabular">
-    <li class="attribute"><%= @creator.active_creator.to_s %></li>
-  </ul>
+    <tr class="repec">
+      <td class="attribute_name"><%= t('creators.repec') -%></td>
+      <td class="attribute_value"><%= @creator.repec -%></td>
+    </tr>
+
+    <tr class="viaf">
+      <td class="attribute_name"><%= t('creators.viaf') -%></td>
+      <td class="attribute_value"><%= @creator.viaf -%></td>
+    </tr>
+
+    <tr class="alternate_names">
+      <td class="attribute_name"><%= t('creators.alternate_names') -%></td>
+      <td class="attribute_value">
+        <ul class="tabular">
+        <% @creator.alternate_names.each do |name| %>
+          <li class="attribute"><%= name %></li>
+        <% end %>
+        </ul>
+      </td>
+    </tr>
+
+
+    </tbody>
+  </table>
+
   <% if current_or_guest_user.can?(:edit, Creator) %>
     <%= link_to 'Edit', edit_creator_path(@creator) %> |
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,12 @@
 
 en:
   hello: "Hello world"
+  creators:
+    display_name: "Display Name"
+    active_creator: "Active"
+    group: "Group"
+    repec: "RePEc"
+    viaf: "VIAF"
+    alternate_names: "Alternate Names"
+    creator: "Creator"
+

--- a/spec/factories/creators.rb
+++ b/spec/factories/creators.rb
@@ -3,5 +3,8 @@
 FactoryBot.define do
   factory :creator do
     display_name { "#{Faker::Name.last_name}, #{Faker::Name.first_name} #{Faker::Name.middle_name}" }
+    repec { Faker::Alphanumeric.unique.alphanumeric(number: 10) }
+    viaf { "http://viaf.org/viaf/#{Faker::Number.unique.number(digits: 14)}" }
+    alternate_names { ["First Alternate", "Second Alternate"] }
   end
 end

--- a/spec/system/creator_spec.rb
+++ b/spec/system/creator_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe 'Creators', :aggregate_failures, type: :system, js: true do
 
     it "does not link to edit an existing creator" do
       visit creator_path(creator)
-      expect(page).to have_content("Display name")
-      expect(page).to have_content("Alternate names")
+      expect(page).to have_content("Display Name")
+      expect(page).to have_content("Alternate Names")
       expect(page).to have_content("RePEc")
       expect(page).to have_content("VIAF")
       expect(page).to have_link("Back")
@@ -90,8 +90,8 @@ RSpec.describe 'Creators', :aggregate_failures, type: :system, js: true do
 
     it "can show an existing creator" do
       visit creator_path(creator)
-      expect(page).to have_content("Display name")
-      expect(page).to have_content("Alternate names")
+      expect(page).to have_content("Display Name")
+      expect(page).to have_content("Alternate Names")
       expect(page).to have_content("RePEc")
       expect(page).to have_content("VIAF")
       expect(page).to have_link("Back")

--- a/spec/views/creators/new.html.erb_spec.rb
+++ b/spec/views/creators/new.html.erb_spec.rb
@@ -1,27 +1,40 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe "creators/new", type: :view do
+RSpec.describe "creators/edit", type: :view do
+  let(:creator) { Creator.new }
+
   before do
-    assign(:creator, Creator.new(
-      display_name: "MyString",
-      alternate_names: "MyString",
-      repec: "MyString",
-      viaf: "MyString"
-    ))
+    assign(:creator, creator)
   end
 
-  skip "renders new creator form" do
+  it 'renders the new creator form', :aggregate_failures do
     render
+    expect(rendered).to have_field('creator_display_name',    name: 'creator[display_name]', text: '')
+    expect(rendered).to have_field('creator_alternate_names', name: 'creator[alternate_names][]')
+    expect(rendered).to have_field('creator_group',           name: 'creator[group]', text: 'unassigned')
+    expect(rendered).to have_field('creator_repec',           name: 'creator[repec]', text: '')
+    expect(rendered).to have_field('creator_viaf',            name: 'creator[viaf]', text: '')
+    expect(rendered).to have_field('creator_active_creator',  name: 'creator[active_creator]', checked: true)
 
-    assert_select "form[action=?][method=?]", creators_path, "post" do
-      assert_select "input[name=?]", "creator[display_name]"
+    expect(rendered).to have_selector("form[@action='#{creators_path}']")
+  end
 
-      assert_select "input[name=?]", "creator[alternate_names]"
+  it 'restricts groups to those provided by the Creator class' do
+    render
+    expect(rendered).to have_select('creator_group', options: ["unassigned", "staff", "consultant"])
+  end
 
-      assert_select "input[name=?]", "creator[repec]"
+  context 'with validation errors' do
+    let(:creator) { FactoryBot.build(:creator, id: 1, group: 'lawful-evil') }
 
-      assert_select "input[name=?]", "creator[viaf]"
+    before do
+      creator.validate
+    end
+
+    it 'displays a top-level error message' do
+      render
+      expect(rendered).to have_selector('.has-error', text: 'Please correct the 1 error below before saving.')
     end
   end
 end

--- a/spec/views/creators/show.html.erb_spec.rb
+++ b/spec/views/creators/show.html.erb_spec.rb
@@ -2,20 +2,32 @@
 require 'rails_helper'
 
 RSpec.describe "creators/show", type: :view do
+  let(:creator) { FactoryBot.build(:creator, id: 1) }
+
   before do
-    @creator = assign(:creator, Creator.create!(
-      display_name: "Display Name",
-      alternate_names: "Alternate Names",
-      repec: "Repec",
-      viaf: "Viaf"
-    ))
+    allow(creator).to receive(:persisted?).and_return(true)
+    assign(:creator, creator)
   end
 
-  skip "renders attributes in <p>" do
+  it 'renders attributes', :aggregate_failures do
     render
-    expect(rendered).to match(/Display Name/)
-    expect(rendered).to match(/Alternate Names/)
-    expect(rendered).to match(/Repec/)
-    expect(rendered).to match(/Viaf/)
+    expect(rendered).to have_selector('.display_name .attribute_value', text: creator.display_name)
+    expect(rendered).to have_selector('.active_creator .attribute_value', text: creator.active_creator)
+    expect(rendered).to have_selector('.group .attribute_value', text: creator.group)
+    expect(rendered).to have_selector('.repec .attribute_value', text: creator.repec)
+    expect(rendered).to have_selector('.viaf .attribute_value', text: creator.viaf)
+    expect(rendered).to have_selector('.alternate_names .attribute_value', text: creator.alternate_names.last)
+  end
+
+  it 'provides an edit link for admins' do
+    allow(controller.current_or_guest_user).to receive(:can?).with(:edit, Creator).and_return(true)
+    render
+    expect(rendered).to have_link('Edit', href: edit_creator_path(creator))
+  end
+
+  it 'suppresses the edit link for regular users' do
+    allow(controller.current_or_guest_user).to receive(:can?).with(:edit, Creator).and_return(false)
+    render
+    expect(rendered).not_to have_link('Edit')
   end
 end


### PR DESCRIPTION
This change adds the creator group to the show view and cleans the view up to be more compact.

The change also adds tests for the show and new views.

**BEFORE**
<img width="2038" height="423" alt="image" src="https://github.com/user-attachments/assets/7e253fae-a9e7-4e6f-823c-0685bab2f55e" />

**AFTER**
<img width="2036" height="378" alt="image" src="https://github.com/user-attachments/assets/8f7feef2-e693-4f4b-a8c9-71ba81ea8aa4" />
