### PR TITLE
Add links from creators in the author report to the works counted

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -8,7 +8,8 @@ class ReportsController < ApplicationController
     add_breadcrumb t(:'hyrax.controls.home'), root_path
     add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path if current_user&.admin?
     add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.reports'), '#'
-    @report = AuthorReportService.run
+    @start_date = 2022
+    @report = AuthorReportService.run(start: @start_date)
   end
 
   private

--- a/app/helpers/author_report_helper.rb
+++ b/app/helpers/author_report_helper.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module AuthorReportHelper
+  def author_formatter(row, key, start)
+    case key
+    when 'name'
+      author_date_facet_link(row, start)
+    else
+      row[key]
+    end
+  end
+
+  def author_date_facet_link(row, start)
+    # pass the plain value back if the row does not have a valid creator id
+    return row['name'] if row['id'].to_i.zero?
+
+    link_to(row['name'], search_path(row, start))
+  end
+
+  def search_path(row, start)
+    search_catalog_path(
+      'f[creator_sim][]': row['name'],
+      'range[date_created_iti][begin]': start,
+      'range[date_created_iti][end]': Date.current.year,
+      'sort': 'date_created_ssi desc'
+    )
+  end
+end

--- a/app/services/author_report_service.rb
+++ b/app/services/author_report_service.rb
@@ -27,7 +27,11 @@ class AuthorReportService
   private
 
   def header_keys
-    ['group', 'id', 'name', '2022', '2023', '2024', '2025', 'total']
+    ['group', 'id', 'name'] + report_periods + ['total']
+  end
+
+  def report_periods
+    @report_periods ||= document_totals.keys
   end
 
   def header_row
@@ -39,16 +43,9 @@ class AuthorReportService
   end
 
   def total_row
-    [{
-      'group' => 'TOTAL',
-      'id' => '',
-      'name' => 'unique documents',
-      '2022' => document_totals['2022'],
-      '2023' => document_totals['2023'],
-      '2024' => document_totals['2024'],
-      '2025' => document_totals['2025'],
-      'total' => @raw_data['response']['numFound']
-    }]
+    [{ 'group' => 'TOTAL', 'id' => '', 'name' => 'unique documents' }
+       .merge(document_totals)
+       .merge('total' => @raw_data['response']['numFound'])]
   end
 
   def document_totals
@@ -96,6 +93,7 @@ class AuthorReportService
     creator_row['id'] = raw_facet['value']
     creator_row['total'] = raw_facet['count']
     raw_facet['pivot'].each do |pivot|
+      # e.g. creator_row [ year ] = publication count for year
       creator_row[pivot['value'].to_s] = pivot['count']
     end
     creator_row

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -16,7 +16,7 @@
       <% @report[1..-1].each do |row| %>
         <tr>
           <% headers.keys.each do |key| %>
-            <td class="<%= "report-#{key}" -%>"><%= row[key] -%></td>
+            <td class="<%= "report-#{key}" -%>"><%= author_formatter(row, key, @start_date) -%></td>
           <% end %>
         </tr>
       <% end %>


### PR DESCRIPTION
This change adds a facet link for each author that's limited to the dates being reported. This supports analysis when publication counts don't match the expected values.

<img width="902" height="838" alt="image" src="https://github.com/user-attachments/assets/b5296b07-b55f-42f8-abfd-47ad552c2863" />
