### PR TITLE
Fix flaky tests

### DIFF
--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -15,3 +15,15 @@
  *= require  'blacklight_range_limit'
  *= require_self
 */
+
+// Disable animations to eliminate certain flaky tests
+<% if Rails.env.test? %>
+*, *::after, *::before {
+  animation: none !important; /* 0*/
+  animation-duration: 1ms !important; /* 1 */
+  animation-delay: -1ms !important; /* 2 */
+  animation-iteration-count: 1 !important; /* 3 */
+  transition-duration: 1ms !important; /* 4 */
+  transition-delay: -1ms !important; /* 5 */
+}
+<% end %>


### PR DESCRIPTION
**ISSUE**
This system test is failing in about 1 of every 5 test runs:
```
  3) New work creation administrative deposit
     Failure/Error: choose 'Publication'

     Capybara::ElementNotFound:
       Unable to find visible radio button "Publication" that is not disabled

     [Screenshot Image]: /Users/mark/_no_backup_/Projects/cypripedium/tmp/capybara/failures_r_spec_example_groups_new_work_creation_administrative_deposit_996.png

     # ./spec/system/new_work_workflow_spec.rb:23:in `block (2 levels) in <top (required)>'
```

**DIAGNOSIS**
The work-type-selection modal dialog is styled with a CSS fade-in transition (e.g. start viible: false, end visible: true) that appears not to be completing reliably to allow Capybara to consistently find the expected elements.

**Resolution**
Disable all CSS animations and transitions in the test environment.

**References**
* https://www.reddit.com/r/rubyonrails/comments/15n53qx/disable_animations_to_stabilize_browser_tests/
* https://marcgg.com/blog/2015/01/05/css-animations-failing-capybara-specs/