### PR TITLE
Allow admins to download author stats in a CSV file

### DIFF
--- a/app/assets/stylesheets/reports.scss
+++ b/app/assets/stylesheets/reports.scss
@@ -1,5 +1,8 @@
 #report {
-  margin-top: 1rem;
+  position: relative;
+  width: max-content;
+  margin-top: -2.75rem;
+
   .table { width: auto;}
   .report-group { width: 5rem;}
   .report-id    { width: 5rem;}
@@ -9,4 +12,10 @@
   .report-2024  { width: 5rem;}
   .report-2025  { width: 5rem;}
   .report-total { width: 5rem;}
+
+  .button_holder {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 1rem;
+  }
 }

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'csv'
 class ReportsController < ApplicationController
   before_action :auth
   with_themed_layout 'dashboard'
@@ -7,9 +8,17 @@ class ReportsController < ApplicationController
   def index
     add_breadcrumb t(:'hyrax.controls.home'), root_path
     add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path if current_user&.admin?
-    add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.reports'), '#'
+    add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.reports')
     @start_date = 2022
     @report = AuthorReportService.run(start: @start_date)
+
+    respond_to do |format|
+      format.html
+      format.csv do
+        response.headers['Content-Type'] = 'text/csv'
+        response.headers['Content-Disposition'] = "attachment; filename=authors-#{@start_date}-#{Date.current.year}.csv"
+      end
+    end
   end
 
   private

--- a/app/services/author_report_service.rb
+++ b/app/services/author_report_service.rb
@@ -39,11 +39,11 @@ class AuthorReportService
   end
 
   def spacer_row(group = nil)
-    [header_keys.index_with { |key| key == 'group' ? group : '' }]
+    [header_keys.index_with { |key| key == 'group' ? group : nil }]
   end
 
   def total_row
-    [{ 'group' => 'TOTAL', 'id' => '', 'name' => 'unique documents' }
+    [{ 'group' => 'TOTAL', 'id' => nil, 'name' => 'unique documents' }
        .merge(document_totals)
        .merge('total' => @raw_data['response']['numFound'])]
   end

--- a/app/views/reports/index.csv.erb
+++ b/app/views/reports/index.csv.erb
@@ -1,0 +1,5 @@
+<% headers = @report[0].keys %>
+<% @report.each do |row_hash| %>
+  <% orderd_row = headers.map{|key| row_hash[key]}  %>
+  <%= CSV.generate_line(orderd_row).html_safe -%>
+<% end %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -4,6 +4,9 @@
 
 <% headers = @report[0] %>
 <div id=report>
+  <div class="button_holder">
+    <%= link_to('Download', reports_path(format: nil, params: { format: :csv }), class: 'btn btn-primary', id: 'reports-download' )%>
+  </div>
   <table class="table  table-striped table-bordered">
     <thead class="thead-dark">
       <tr>

--- a/spec/requests/reports_request_spec.rb
+++ b/spec/requests/reports_request_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe "/reports", type: :request do
         get reports_path
         expect(response).to be_successful
       end
+
+      it "accepts CSV format rquests" do
+        get reports_path(format: nil, params: { format: :csv })
+        expect(response.headers).to include("Content-Type" => "text/csv", "Content-Disposition" => /attachment/)
+      end
     end
 
     # Only the #index action should be routable, all the others should return a 404

--- a/spec/views/reports/index.html.erb_spec.rb
+++ b/spec/views/reports/index.html.erb_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "reports/index", :aggregate_failures, type: :view do
       }
     ]
   end
+
   before do
     assign(:report, report)
     assign(:start_date, 2022)
@@ -62,7 +63,12 @@ RSpec.describe "reports/index", :aggregate_failures, type: :view do
     expect(rendered).to have_selector('td.report-2025', text: '18')
   end
 
-  describe 'creator cell' do
+  it 'has a CSV download link' do
+    render
+    expect(rendered).to have_link(id: 'reports-download', href: '/reports?format=csv')
+  end
+
+  describe 'each creator name' do
     let(:creator) { FactoryBot.create(:creator) }
     before {
       report << {
@@ -75,7 +81,7 @@ RSpec.describe "reports/index", :aggregate_failures, type: :view do
       }
     }
 
-    it 'has links to the counted documents' do
+    it 'has a link to documents by that author' do
       render
       expect(rendered).to have_link(creator.display_name, href: /\/catalog.*&range%5Bdate_created_iti%5D%5Bbegin%5D=2022/)
     end


### PR DESCRIPTION
This change adds code to export the author publication statistics in a CSV file and adds a download button to the upper right of the report page.

<img width="907" height="369" alt="image" src="https://github.com/user-attachments/assets/756f9092-e7b8-4849-bf32-d755a6dbb1ea" />
