### PR TITLE
Add user UI to select starting year and interval for author reports

### DIFF
--- a/app/assets/stylesheets/reports.scss
+++ b/app/assets/stylesheets/reports.scss
@@ -1,7 +1,6 @@
 #report {
   position: relative;
   width: max-content;
-  margin-top: -2.75rem;
 
   .table { width: auto;}
   .report-group { width: 5rem;}
@@ -15,7 +14,18 @@
 
   .button_holder {
     display: flex;
-    justify-content: flex-end;
+    justify-content: space-between;
     margin-bottom: 1rem;
+  }
+
+  #reporting_options {
+    select {
+      margin-right: 1rem;
+      padding: 0.25rem;
+    }
+
+    label {
+      margin-bottom: 0;
+    }
   }
 }

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -9,7 +9,9 @@ class ReportsController < ApplicationController
     add_breadcrumb t(:'hyrax.controls.home'), root_path
     add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path if current_user&.admin?
     add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.reports')
-    @report = AuthorReportService.run(start: params[:start_date], period: params[:period])
+    @start_date = params[:start_date] || 3.years.ago.beginning_of_year.utc.iso8601
+    @period = params[:period] || 'yearly'
+    @report = AuthorReportService.run(start: @start_date, period: @period)
 
     respond_to do |format|
       format.html

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -3,9 +3,18 @@
 <% end %>
 
 <% headers = @report[0] %>
-<% start = headers.keys[3][0..3] # year from first date column %>
+<% available_years = (2018..Date.current.year).map{|y| [y.to_s, y.to_s + '-01-01T00:00:00Z']}.reverse %>
 <div id=report>
   <div class="button_holder">
+    <div id="reporting_options">
+      <%= form_with method: :get, local: true, skip_enforcing_utf8: true do |report_options| %>
+        <%= report_options.label :start_date, 'Start:' %>
+        <%= report_options.select :start_date, available_years, selected: @start_date %>
+        <%= report_options.label :period, 'Interval:' %>
+        <%= report_options.select :period, ['yearly', 'quarterly', 'monthly'], selected: @period %>
+        <%= report_options.submit 'Refresh', name: '', class: 'btn btn-info' %>
+      <% end %>
+    </div>
     <%= link_to('Download', reports_path(format: nil, params: { format: :csv }), class: 'btn btn-primary', id: 'reports-download' )%>
   </div>
   <table class="table  table-striped table-bordered">
@@ -20,7 +29,7 @@
       <% @report[1..-1].each do |row| %>
         <tr>
           <% headers.keys.each do |key| %>
-            <td class="<%= "report-#{key.parameterize}" -%>"><%= author_formatter(row, key, start) -%></td>
+            <td class="<%= "report-#{key.parameterize}" -%>"><%= author_formatter(row, key, @start_date) -%></td>
           <% end %>
         </tr>
       <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,10 @@ module Cypripedium
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    # We have to explicitly turn on fomr helper ids since we are loading Rails 5.1 defaults
+    # see https://edgeguides.rubyonrails.org/5_2_release_notes.html#action-view-notable-changes
+    config.action_view.form_with_generates_ids = true
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/spec/views/reports/index.html.erb_spec.rb
+++ b/spec/views/reports/index.html.erb_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe "reports/index", :aggregate_failures, type: :view do
 
   before do
     assign(:report, report)
+    assign(:start_date, '2022-01-01T00:00:00Z')
+    assign(:period, 'yearly')
   end
 
   it 'renders a header row' do
@@ -83,6 +85,29 @@ RSpec.describe "reports/index", :aggregate_failures, type: :view do
     it 'has a link to documents by that author' do
       render
       expect(rendered).to have_link(creator.display_name, href: /\/catalog.*&range%5Bdate_created_iti%5D%5Bbegin%5D=2022/)
+    end
+  end
+
+  describe 'user input' do
+    it 'lets you select the starting year' do
+      render
+      expect(rendered).to have_select('start_date', selected: '2022')
+    end
+
+    it 'reporting period defaults to yearly' do
+      render
+      expect(rendered).to have_select('period', selected: 'yearly')
+    end
+
+    it 'allows you to select yearly, quarterly, or montly reporting periods' do
+      render
+      expect(rendered).to have_select('period', options: ["yearly", "quarterly", "monthly"])
+    end
+
+    it 'has a button to refresh the page with the new options' do
+      render
+      expect(rendered).to have_button('Refresh')
+      expect(rendered).to have_selector("form[@action='#{reports_path}'][@method='get']")
     end
   end
 end


### PR DESCRIPTION
This change allows the Admin to select a starting year and reporting interval (yearly, quarterly, or monthly) for the report.

**Sample Screenshot**
<img width="816" height="248" alt="image" src="https://github.com/user-attachments/assets/ab23ec12-669a-4cf6-b71a-318d446215a4" />
