### PR TITLE
Leave cells blank instead of 0 in author report

### DIFF
--- a/app/services/author_report_service.rb
+++ b/app/services/author_report_service.rb
@@ -117,8 +117,8 @@ class AuthorReportService
     creator_row['id'] = raw_facet['value']
     creator_row['total'] = raw_facet['count']
     counts = raw_facet['ranges']['date_uploaded_dtsi']['counts']
-    counts.each_cons(2) do |period, count|
-      creator_row[period] = count unless count == 0
+    counts.each_slice(2) do |period, count|
+      creator_row[period] = count unless count.zero?
     end
     creator_row
   end


### PR DESCRIPTION
**ISSUE**
The update to use date_uploaded_dtsi as the basis for author stats reporting added zero-counts to the results so that there would not be any gaps in reporting periods. This had the side effect of displaying 0 for periods where authors didn't publish any works, instead of leaving them blank as previously.

The extra 0s make the table much harder to scan for acutal publications,

**REOLUTION**
We introduced code to suppress zeros in author counts and leave the cell blank instead.