### PR TITLE
Fix author link in Publication Report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,14 +32,6 @@ jobs:
 
         steps:
             - checkout
-
-            - run:
-                name: Setup Code Climate test-reporter
-                command: |
-                    # download test reporter as a static binary
-                    curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-                    chmod +x ./cc-test-reporter
-
             - browser-tools/install-chrome
             - browser-tools/install-chromedriver
 
@@ -69,14 +61,10 @@ jobs:
 
             - samvera/install_solr_core
 
-            - run: ./cc-test-reporter before-build
-
             - samvera/parallel_rspec
 
             - coveralls/upload:
                   path_to_lcov: ./coverage/lcov/project.lcov
-
-            - run: ./cc-test-reporter after-build --coverage-input-type simplecov
 
 workflows:
     version: 2

--- a/app/helpers/author_report_helper.rb
+++ b/app/helpers/author_report_helper.rb
@@ -17,10 +17,12 @@ module AuthorReportHelper
     link_to(row['name'], search_path(row, start))
   end
 
+  # Returns a search link for date range + author facet
+  # should be in the form https://researchdatabase.minneapolisfed.org/catalog?f%5Bcreator_sim%5D%5B%5D=Bianchi%2C+Javier&range%5Bdate_created_iti%5D%5Bbegin%5D=2022&range%5Bdate_created_iti%5D%5Bend%5D=2026
   def search_path(row, start)
     search_catalog_path(
       'f[creator_sim][]': row['name'],
-      'range[date_created_iti][begin]': start,
+      'range[date_created_iti][begin]': start.to_s[0..3],
       'range[date_created_iti][end]': Date.current.year,
       'sort': 'date_created_ssi desc'
     )

--- a/spec/views/reports/index.html.erb_spec.rb
+++ b/spec/views/reports/index.html.erb_spec.rb
@@ -83,8 +83,9 @@ RSpec.describe "reports/index", :aggregate_failures, type: :view do
     }
 
     it 'has a link to documents by that author' do
+      travel_to('2025-03-17T05:26:48Z')
       render
-      expect(rendered).to have_link(creator.display_name, href: /\/catalog.*&range%5Bdate_created_iti%5D%5Bbegin%5D=2022/)
+      expect(rendered).to have_link(creator.display_name, href: /\/catalog.*&range%5Bdate_created_iti%5D%5Bbegin%5D=2022&range%5Bdate_created_iti%5D%5Bend%5D=2025/)
     end
   end
 


### PR DESCRIPTION
**ISSUE**
Clicking on an author link in the Publication Statistics report returns the message: "Sorry, I don't understand your search."

**DIAGNOSIS**
We were passing a full timestamp in ISO8601 format, ex. "2022-01-01T00:00:00Z" to a search against the field `date_created_iti` which can only compare against integer values.

**FIX**
Ensure the date is represented as a string and only pass the first 4 characters to the search link.