### PR TITLE
Fix CSV download parameters

### DIFF
--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -15,7 +15,7 @@
         <%= report_options.submit 'Refresh', name: '', class: 'btn btn-info' %>
       <% end %>
     </div>
-    <%= link_to('Download', reports_path(format: nil, params: { format: :csv }), class: 'btn btn-primary', id: 'reports-download' )%>
+    <%= link_to('Download', reports_path(format: nil, params: { format: :csv, start_date: @start_date, period: @period }), class: 'btn btn-primary', id: 'reports-download' )%>
   </div>
   <table class="table  table-striped table-bordered">
     <thead class="thead-dark">

--- a/spec/views/reports/index.html.erb_spec.rb
+++ b/spec/views/reports/index.html.erb_spec.rb
@@ -66,7 +66,13 @@ RSpec.describe "reports/index", :aggregate_failures, type: :view do
 
   it 'has a CSV download link' do
     render
-    expect(rendered).to have_link(id: 'reports-download', href: '/reports?format=csv')
+    expect(rendered).to have_link(id: 'reports-download', href: /\/reports/)
+  end
+
+  it 'populates the download link with the report params' do
+    assign(:period, 'quarterly')
+    render
+    expect(rendered).to have_link(id: 'reports-download', href: /period=quarterly/)
   end
 
   describe 'each creator name' do


### PR DESCRIPTION
**ISSUE**
Author stats downloads were always using the default report values.

**RESOLUTION**
Ensure the download link includes any report start or period parameters.

**AFTER**
<img width="1578" height="893" alt="image" src="https://github.com/user-attachments/assets/893dca2b-6217-4d23-89cf-951d1aeaf171" />
