### PR TITLE
FIX: Update the web-console gem to restore detailed debugging info

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ group :development do
   gem 'capistrano-rails'
   gem 'capistrano-sidekiq'
   gem 'listen'
-  gem 'web-console', '~> 3.7'
+  gem 'web-console'
   gem 'xray-rails'
   gem 'yard'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
     benchmark (0.4.1)
-    bigdecimal (3.2.2)
+    bigdecimal (3.3.1)
     bindex (0.8.1)
     bixby (5.0.2)
       rubocop (= 1.28.2)
@@ -236,7 +236,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.3.4)
-    connection_pool (2.5.3)
+    connection_pool (2.5.4)
     crass (1.0.6)
     csl (2.0.0)
       namae (~> 1.0)
@@ -559,7 +559,7 @@ GEM
       activesupport
     iiif_manifest (1.6.0)
       activesupport (>= 4)
-    io-console (0.8.0)
+    io-console (0.8.1)
     irb (1.15.2)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
@@ -680,7 +680,7 @@ GEM
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.25.5)
+    minitest (5.26.0)
     msgpack (1.7.5)
     multi_json (1.15.0)
     multi_xml (0.7.2)
@@ -716,7 +716,7 @@ GEM
     noid-rails (3.2.0)
       actionpack (>= 5.0.0, < 8)
       noid (~> 0.9)
-    nokogiri (1.18.9)
+    nokogiri (1.18.10)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oauth (1.1.0)
@@ -744,7 +744,7 @@ GEM
     parslet (2.0.0)
     pg (1.5.9)
     popper_js (1.16.1)
-    pp (0.6.2)
+    pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
     psych (3.3.4)
@@ -816,7 +816,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.2.1)
+    rake (13.3.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
@@ -914,7 +914,7 @@ GEM
       activemodel (>= 5.0)
       reform (>= 2.3.1, < 3.0.0)
     regexp_parser (2.10.0)
-    reline (0.6.1)
+    reline (0.6.2)
       io-console (~> 0.5)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -1137,11 +1137,11 @@ GEM
       method_source (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-    web-console (3.7.0)
-      actionview (>= 5.0)
-      activemodel (>= 5.0)
+    web-console (4.2.1)
+      actionview (>= 6.0.0)
+      activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
-      railties (>= 5.0)
+      railties (>= 6.0.0)
     webdrivers (5.3.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -1166,7 +1166,7 @@ GEM
       rdf (~> 3.3)
       rdf-xsd (~> 3.3)
     yard (0.9.37)
-    zeitwerk (2.7.2)
+    zeitwerk (2.7.3)
 
 PLATFORMS
   ruby
@@ -1228,7 +1228,7 @@ DEPENDENCIES
   twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
   tzinfo-data
   uglifier (>= 1.3.0)
-  web-console (~> 3.7)
+  web-console
   webdrivers
   whenever
   xray-rails


### PR DESCRIPTION
**ISSUE**
An older, incompatible, version of the web-console gem was preventing us from seeing detailed errors in the browser in development environments.

**RESOLUTION**
Updating to the latest compatible version of the gem resolved our issues.

**BEFORE**
"We're Sorry, but something went wrong."

**AFTER**
<img width="1364" height="817" alt="image" src="https://github.com/user-attachments/assets/ff873de6-3829-4b81-95dd-2a1549fca38d" />
