### PR TITLE
Refactor Publication factory to generate dynamic data

### DIFF
--- a/spec/factories/publication.rb
+++ b/spec/factories/publication.rb
@@ -2,21 +2,23 @@
 
 FactoryBot.define do
   factory :publication do
-    title { ["Testing"] }
+    title { [Faker::Book.title] }
+
     factory :populated_publication do
+      # id { Noid::Rails::Service.new.mint }
       transient do
-        creators { create_list(:creator, 2) }
+        creators { create_list(:creator, 1) }
       end
-      title { ["The 1929 Stock Market: Irving Fisher Was Right: Additional Files"] }
       creator { creators.map(&:display_name) }
       creator_id { creators.map(&:id) }
       series { ["Staff Report (Federal Reserve Bank of Minneapolis. Research Department)"] }
-      resource_type { ["Dataset"] }
+      resource_type { ["Report"] }
       visibility { "open" }
-      abstract { ["This is my abstract"] }
-      identifier { ["https://doi.org/10.21034/sr.600"] }
-      description { ["This is my description"] }
+      abstract { [Faker::Lorem.paragraph] }
+      sequence(:identifier) { |n| ["https://doi.org/10.21034/sr.#{n}"] }
+      description { [Faker::Lorem.paragraph] }
     end
+
     transient do
       file_sets { [] }
     end

--- a/spec/system/google_structured_data_spec.rb
+++ b/spec/system/google_structured_data_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Use structured data that Google can parse', type: :system, clean
     end
   end
   context "publications" do
-    let(:work) { FactoryBot.create(:populated_publication) }
+    let(:work) { FactoryBot.create(:populated_publication, abstract: ['This is my abstract']) }
     it "marks abstract with schema.org tags" do
       visit "/concern/publications/#{work.id}"
       expect(page).to have_css('[itemprop="abstract"]', text: 'This is my abstract')


### PR DESCRIPTION
**ISSUE**
The Publication factory used static data, making it difficult to use for tests that required comparing multiple objects with unique data.

**RESOLUTION**
Refactor the factory to use Faker data for work attributes.