### PR TITLE
Refactor to remove unnecessary Dataset factory

### DIFF
--- a/spec/factories/dataset.rb
+++ b/spec/factories/dataset.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :dataset do
     title { ['Testing'] }
 
-    factory :dataset_without_description do
+    factory :populated_dataset do
       transient do
         creators { create_list(:creator, 2) }
       end
@@ -17,11 +17,8 @@ FactoryBot.define do
       abstract { ["This is my abstract"] }
       identifier { ["https://doi.org/10.21034/sr.600"] }
       related_url { ["Data supports Staff Report 315, \"Does Neoclassical Theory Account for the Effects of Big Fiscal Shocks? Evidence From World War II.\" https://doi.org/10.21034/sr.315"] }
-
-      factory :populated_dataset do
-        description { ["This is my description"] }
-        license { ["https://creativecommons.org/licenses/by-nc/4.0/"] }
-      end
+      description { ["This is my description"] }
+      license { ["https://creativecommons.org/licenses/by-nc/4.0/"] }
     end
   end
 end

--- a/spec/system/google_structured_data_spec.rb
+++ b/spec/system/google_structured_data_spec.rb
@@ -21,18 +21,13 @@ RSpec.describe 'Use structured data that Google can parse', type: :system, clean
       expect(page).not_to have_css('[itemprop="description"][itemtype]')
       expect(page).to have_css('[itemprop="license"][itemtype="http://schema.org/CreativeWork"]', text: "Creative Commons BY-NC Attribution-NonCommercial 4.0 International")
     end
-  end
 
-  context "dataset without description field" do
-    let(:work) { FactoryBot.create(:dataset_without_description) }
-    let(:related_url) do
-      "Data supports Staff Report 315, \"Does Neoclassical Theory Account for the Effects of Big Fiscal Shocks? Evidence From World War II.\" https://doi.org/10.21034/sr.315"
-    end
     it "marks related_url with description schema.org tags" do
       visit "/concern/datasets/#{work.id}"
-      expect(page).to have_css('[itemprop="description"]', text: related_url)
+      expect(page).to have_css('[itemprop="description"]', text: work.related_url.first)
     end
   end
+
   context "publications" do
     let(:work) { FactoryBot.create(:populated_publication, abstract: ['This is my abstract']) }
     it "marks abstract with schema.org tags" do


### PR DESCRIPTION
**RATIONALE**
The two nested factories can easily be collapsed into one without impacting the intention of any tests.