### PR TITLE
Handle Runtime environment badge edge cases

### DIFF
--- a/app/lib/runtime_info.rb
+++ b/app/lib/runtime_info.rb
@@ -33,6 +33,8 @@ class RuntimeInfo
           return nil unless ec2?
           metadata_client = Aws::EC2Metadata.new
           metadata_client.get('/latest/meta-data/tags/instance/Environment')
+        rescue Aws::EC2Metadata::MetadataNotFoundError
+          'tag diabled or missing'
         rescue Errno::EHOSTDOWN, Net::OpenTimeout, Errno::EHOSTUNREACH
           # just return nil without an exception
         end


### PR DESCRIPTION
**ISSUE**
The runtime_info RuntimeInfo expects a tag named "Environment" to be set on all AWS instances. In cases where the tag is not set for and EC2 instance, an exception would be raised causing the header, and therefore all pages, not to load.

**RESOLUTION**
Add exception handling for the edge-case where the application *is* running on EC2, but no "Environment" tag has been set.