### PR TITLE
Override Hyrax code that relies on exception-based flow control

### DIFF
--- a/app/patches/extensions/presents_attributes.rb
+++ b/app/patches/extensions/presents_attributes.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Override the #available_member_works
+# default to sort by volume & issue number
+# when no user supplied search sort parameters are present
+module Extensions
+  module PresentsAttributes
+    def self.included(k)
+      k.class_eval do
+        private
+
+        def find_renderer_class(name)
+          render_class = "#{name.to_s.camelize}AttributeRenderer".to_sym
+          if Hyrax::Renderers.const_defined?(render_class)
+            Hyrax::Renderers.const_get(render_class)
+          else
+            Hyrax.logger.error("Invalid attribute renderer Hyrax::#{render_class}, using 'Hyrax::AttributeRenderer'")
+            Renderers::AttributeRenderer
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/renderers/hyrax/renderers/markdown_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/markdown_attribute_renderer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Renderers
+    # This is used by PresentsAttributes to render fields that include Markdown formatting
+    #   e.g.: presenter.attribute_to_html(:abstract, render_as: :markdown)
+    class MarkdownAttributeRenderer < AttributeRenderer
+      private
+
+      def attribute_value_to_html(value)
+        renderer = Redcarpet::Render::HTML.new(escape_html: true)
+        markdown = Redcarpet::Markdown.new(renderer, autolink: true)
+        if microdata_value_attributes(field)
+          "<span#{html_attributes(microdata_value_attributes(field))}>#{markdown.render(value)}</span>"
+        else
+          markdown.render(value)
+        end
+      end
+    end
+  end
+end

--- a/app/views/shared/_citations.html.erb
+++ b/app/views/shared/_citations.html.erb
@@ -1,0 +1,56 @@
+<% content_for(:twitter_meta) do %>
+  <meta name="twitter:card" content="product" />
+  <meta name="twitter:site" content="<%= t('hyrax.product_twitter_handle') %>" />
+  <meta name="twitter:creator" content="<%= @presenter.tweeter %>" />
+  <meta property="og:site_name" content="<%= application_name %>" />
+  <meta property="og:type" content="object" />
+  <meta property="og:title" content="<%= @presenter.title.first %>" />
+	<%# previously meta property="og:description" content="<.= @presenter.description.first.truncate(200) rescue @presenter.title.first >" / %>
+  <meta property="og:description" content="<%= @presenter.description.first&.truncate(200) || @presenter.title.first %>" />
+  <meta property="og:image" content="<%= @presenter.download_url %>" />
+  <meta property="og:url" content="<%= polymorphic_url([main_app, @presenter]) %>" />
+  <meta name="twitter:data1" content="<%= @presenter.keyword.join(', ') %>" />
+  <meta name="twitter:label1" content="Keywords" />
+  <meta name="twitter:data2" content="<%= @presenter.rights_statement.first %>" />
+  <meta name="twitter:label2" content="Rights Statement" />
+<% end %>
+
+<%= content_for(:twitter_meta) %>
+
+<% gscholar = Hyrax::GoogleScholarPresenter.new(@presenter) %>
+
+<% if gscholar.scholarly? %>
+<% content_for(:gscholar_meta) do %>
+  <meta name="description" content="<%= gscholar.description %>" />
+  <meta name="citation_title" content="<%= gscholar.title %>" />
+
+  <% gscholar.authors.each do |author| %>
+  <meta name="citation_author" content="<%= author %>" />
+  <% end %>
+
+  <% if gscholar.publication_date.present? %>
+  <meta name="citation_publication_date" content="<%= gscholar.publication_date %>" />
+  <% end %>
+
+  <% if gscholar.pdf_url.present? %>
+  <meta name="citation_pdf_url" content="<%= gscholar.pdf_url %>" />
+  <% end %>
+
+  <% if gscholar.keywords.present? %>
+  <meta name="citation_keywords" content="<%= gscholar.keywords %>" />
+  <% end %>
+
+  <% if gscholar.publisher.present? %>
+  <meta name="citation_publisher" content="<%= gscholar.publisher %>" />
+  <% end %>
+
+  <!-- Hyrax does not yet support these metadata -->
+  <!--
+    <meta name="citation_journal_title" content=""/>
+    <meta name="citation_volume" content=""/>
+    <meta name="citation_issue" content=""/>
+    <meta name="citation_firstpage" content=""/>
+    <meta name="citation_lastpage" content=""/>
+  -->
+<% end %>
+<% end %>

--- a/config/initializers/patches.rb
+++ b/config/initializers/patches.rb
@@ -6,4 +6,5 @@ ActiveSupport::Reloader.to_prepare do
   Hyrax::Collections::CollectionMemberSearchService.include(Extensions::CollectionMemberSearchService)
   Hydra::FileCharacterization::Characterizers::Fits.include(Extensions::ServletCharacterizer)
   Deprecation.include(Extensions::DeprecationReporting)
+  Hyrax::PresentsAttributes.include(Extensions::PresentsAttributes)
 end


### PR DESCRIPTION
**ISSUE**
Significant numbers of exctptions were appearing in the log because the attribute renderer and citation partial used on most pages rely on exception based flow control.

* https://github.com/samvera/hyrax/blob/hyrax-v5.1.0/app/presenters/hyrax/presents_attributes.rb#L55
* https://github.com/samvera/hyrax/blob/hyrax-v5.1.0/app/views/shared/_citations.html.erb#L8

**RESOLUTION**
Refactor the code to avoid exception based flow control and override locally until and upstream fix can be released.