### PR TITLE
Patch Qualys flagged unencoded parameters

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,8 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  before_action :encode_parentheses
+
   rescue_from I18n::InvalidLocale, with: :render_406
 
   def render_406 # rubocop:disable Naming/VariableNumber
@@ -25,5 +27,11 @@ class ApplicationController < ActionController::Base
   def append_info_to_payload(payload)
     super
     payload[:request_id] = request.request_id
+  end
+
+  def encode_parentheses
+    request.query_parameters.each do |key, value|
+      params[key] = CGI.escapeURIComponent(value) if value.is_a?(String) && /[)(]/.match?(value)
+    end
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,6 +2,8 @@
 
 class PagesController < ApplicationController
   def error_404 # rubocop:disable Naming/VariableNumber
+    # Clear params so we don't reflect any injection attacks
+    params.slice!(:controller, :action, :path)
     flash[:alert] = 'The page you are looking for does not exist.'
     render file: Rails.public_path.join('404.html'), status: :not_found
   end

--- a/spec/system/qualys_cross_site_scripting_spec.rb
+++ b/spec/system/qualys_cross_site_scripting_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+describe 'Qualys patches' do
+  # NOTE: these tests use the test string used by Qualys.
+  # The test string is somewhat long and sometimes obscures the goal of individual tests.
+  # However, for now, we've decided to keep the longer form to make comparing the resutls to Qalys reports eaiser.
+  context 'for "150084 unencoded character injection"' do
+    it 'replaces potentially dangerous characters in ATOM feeds' do
+      visit "/catalog.atom?q=discovery%22%3E%3CDIV%20STYLE%3D%22width%3Aexpression(qssX140136678030192Y4_1Z%3D7)%22%3E"
+      expect(page.find('title').text).to eq('discovery%22%3E%3CDIV%20STYLE%3D%22width%3Aexpression%28qssX140136678030192Y4_1Z%3D7%29%22%3E - Research Database Search Results')
+    end
+
+    it 'does not reflect invalid query strings' do
+      visit '/catalog/bad_unique_id?&q=*&DummyField=discovery%22%3E%3CDIV%20STYLE%3D%22width%3Aexpression(qssX140136678030192Y4_1Z%3D7)%22%3E&search_field=all_fields'
+      expect(page).to have_no_field('DummyField', type: 'hidden')
+    end
+
+    it 'encodes parenthesis in the per_page parameter' do
+      visit '/catalog?q=&per_page="><DIV STYLE="width:expression(qssX140544040006928Y1_1Z-7)">'
+      expect(page).to have_field('per_page', type: 'hidden', with: '%22%3E%3CDIV%20STYLE%3D%22width%3Aexpression%28qssX140544040006928Y1_1Z-7%29%22%3E')
+    end
+
+    it 'encodes parenthesis in arbitrary parameters' do
+      visit '/catalog?q=&foo="><DIV STYLE="width:expression(qssX140544040006928Y1_1Z-7)">'
+      expect(page).to have_field('foo', type: 'hidden', with: '%22%3E%3CDIV%20STYLE%3D%22width%3Aexpression%28qssX140544040006928Y1_1Z-7%29%22%3E')
+    end
+
+    it 'does not modify existing encodings' do
+      encoded = '%22%3E%3CDIV%20STYLE%3D%22width%3Aexpression%28qssX140043725525456Y3_1Z%3D7%29%22%3E'
+      visit "/catalog?q=&foo=#{encoded}"
+      expect(page).to have_field('foo', type: 'hidden', with: encoded)
+    end
+  end
+end


### PR DESCRIPTION
**ISSUE**
Qualys scans report a large number of potential unencoded character vulnerabilites. We believe that the application sufficiently protects from the potential threat vector, but we want to eliminate the issues from Qualys report to achieve a clean baseline.

**RESOLUTION**
1) Ensure query parameters are escaped before reflecting them back in search output.
2) Clear any invalid query parameters on invalid requests.

**Qualys Details**
>**Threat**
>The web application reflects potentially dangerous characters such as single quotes, double quotes, and angle brackets. These characters are commonly used for HTML injection attacks such as cross-site scripting (XSS).
>**Impact**
>No exploit was determined for these reflected characters. The input parameter should be manually analyzed to verify that no other characters can be injected that would lead to an HTML injection (XSS) vulnerability.
>**Solution**
>Review the reflected characters to ensure that they are properly handled as defined by the web application's coding practice. Typical solutions are to apply HTML encoding or percent encoding to the characters depending on where they are placed in the HTML. For example, a double quote might be encoded as " when displayed in a text node, but as %22 when placed in the value of an href attribute.