### PR TITLE
Add an Export model to support BagIt exports

### DIFF
--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Export < ApplicationRecord
+  enum :status, [:unknown, :queued, :working, :failed, :completed], default: :unknown
+  enum :format, [:zip, :bag], scopes: false
+  belongs_to :user
+  has_one_attached :export_file
+
+  validates :format, presence: true
+  validates :items, length: { minimum: 1 }
+end

--- a/db/migrate/20260603212051_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20260603212051_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/migrate/20260603224141_create_exports.rb
+++ b/db/migrate/20260603224141_create_exports.rb
@@ -1,0 +1,13 @@
+class CreateExports < ActiveRecord::Migration[7.2]
+  def change
+    create_table :exports do |t|
+      t.belongs_to :user, null: false, foreign_key: true
+      t.string :items, array: true, default: []
+      t.integer :format, null: false
+      t.integer :status, null: false, default: 0
+      t.string :message
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_15_180758) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_03_224141) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "bookmarks", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
@@ -100,6 +128,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_15_180758) do
     t.index ["parent_id"], name: "index_curation_concerns_operations_on_parent_id"
     t.index ["rgt"], name: "index_curation_concerns_operations_on_rgt"
     t.index ["user_id"], name: "index_curation_concerns_operations_on_user_id"
+  end
+
+  create_table "exports", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "items", default: [], array: true
+    t.integer "format", null: false
+    t.integer "status", default: 0, null: false
+    t.string "message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_exports_on_user_id"
   end
 
   create_table "featured_works", id: :serial, force: :cascade do |t|
@@ -593,8 +632,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_15_180758) do
     t.integer "status", default: 0
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "collection_type_participants", "hyrax_collection_types"
   add_foreign_key "curation_concerns_operations", "users"
+  add_foreign_key "exports", "users"
   add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
   add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"
   add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id", name: "receipts_on_notification_id"

--- a/spec/models/export_spec.rb
+++ b/spec/models/export_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Export, type: :model do
+  subject(:export) { described_class.new(user: user, format: :zip, items: ['abc123']) }
+
+  let(:user) { create(:user) }
+
+  describe 'associations' do
+    it 'belongs to a user' do
+      expect(export.user).to eq user
+    end
+
+    it 'has one attached export_file' do
+      expect(export).to respond_to(:export_file)
+    end
+  end
+
+  describe 'validations' do
+    it 'requires a user, format, and at least one item' do
+      expect(export).to be_valid
+    end
+
+    it 'is invalid without a user' do
+      export.user = nil
+      expect(export).not_to be_valid
+      expect(export.errors[:user]).to be_present
+    end
+
+    it 'is invalid without a format' do
+      export.format = nil
+      expect(export).not_to be_valid
+      expect(export.errors[:format]).to be_present
+    end
+
+    it 'is invalid without items' do
+      export.items = []
+      expect(export).not_to be_valid
+      expect(export.errors[:items]).to be_present
+    end
+  end
+
+  describe '#items' do
+    it 'is an array' do
+      expect(export.items).to be_an Array
+    end
+
+    it 'accepts an array of id strings' do
+      export.items = ['abc123', 'def456']
+      export.save!
+      expect(export.reload.items).to eq ['abc123', 'def456']
+    end
+  end
+
+  describe '#format' do
+    it 'accepts :zip' do
+      export.format = :zip
+      expect(export).to be_valid
+    end
+
+    it 'accepts :bag' do
+      export.format = :bag
+      expect(export).to be_valid
+    end
+
+    it 'rejects unknown formats' do
+      expect { export.format = :unknown_format }
+        .to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#status' do
+    it 'defaults to :unknown' do
+      expect(export.status).to eq 'unknown'
+    end
+
+    it 'includes expected states' do
+      expect(described_class.statuses.keys).to include('unknown', 'queued', 'working', 'failed', 'completed')
+    end
+
+    it 'rejects unknown statuses' do
+      expect { export.status = :bogus }
+        .to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#message' do
+    it 'is nil by default' do
+      expect(export.message).to be_nil
+    end
+
+    it 'persists a human-readable status description' do
+      export.message = 'Export failed: source file not found'
+      export.save!
+      expect(export.reload.message).to eq 'Export failed: source file not found'
+    end
+  end
+
+  describe 'system user' do
+    it 'can be assigned User.system_user as the submitting user' do
+      system_export = described_class.new(user: User.system_user, format: :zip, items: ['abc123'])
+      expect(system_export).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
This adds the basic ActiveRecord based model to track bags and their processing status.