### PR TITLE
Add code to run export jobs in the background

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
           CACHE_PATH: /tmp/cache
           FCREPO_TEST_URL: http://127.0.0.1:8080/rest/
           SOLR_TEST_URL: http://127.0.0.1:8985/solr/hydra-test
+          RDF_URI: http://localhost:3000
         executor:
             name: samvera/ruby_fcrepo_solr_redis_postgres
             ruby_version: << parameters.ruby_version >>

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+require 'csv'
+
+class ExportJob < ApplicationJob
+  METADATA_HEADERS = ['title', 'name-creator', 'name-author', 'dateCreated',
+                      'dateModified', 'abstract', 'location-url',
+                      'identifier', 'tableOfContents'].freeze
+
+  SUPPORTED_TYPES = [Publication, Dataset, ConferenceProceeding].freeze
+
+  def perform(export)
+    @export = export
+    @export.working!
+    @metadata_rows = []
+
+    Dir.mktmpdir do |tmp_dir|
+      @bag = BagIt::Bag.new(File.join(tmp_dir, bag_name))
+      build_bag
+      write_metadata_csv
+      zip_path = compress(tmp_dir)
+      attach(zip_path)
+    end
+
+    @export.completed!
+    notify(success: true)
+  rescue StandardError => e
+    @export.update!(status: :failed, message: e.message)
+    notify(success: false)
+  end
+
+  private
+
+  def bag_name
+    "#{Rails.application.config.bag_prefix}_#{@export.id}"
+  end
+
+  def build_bag
+    @export.items.each do |item_id|
+      work = ActiveFedora::Base.find(item_id)
+      add_item_to_bag(work)
+    end
+    @bag.manifest!(algo: 'sha256')
+  end
+
+  def write_metadata_csv
+    @bag.add_file('metadata.csv') do |io|
+      csv = CSV.new(io, headers: METADATA_HEADERS, write_headers: true)
+      @metadata_rows.each { |row| csv << row }
+    end
+  end
+
+  def location_url(work)
+    type_path = work.class.to_s.underscore.pluralize
+    "#{Rails.application.config.rdf_uri}/concern/#{type_path}/#{work.id}"
+  end
+
+  def add_item_to_bag(work)
+    raise "Unsupported work type: #{work.class}" unless SUPPORTED_TYPES.include?(work.class)
+    add_metadata_for_bag(work)
+    add_files_to_bag(work)
+  end
+
+  def add_metadata_for_bag(work)
+    @metadata_rows << [
+      work.title.first,
+      work.corporate_name.first,
+      work.creator.sort.join('|'), # list creators in alphabetical order
+      work.date_created.first,
+      work.date_modified,
+      work.abstract.first,
+      location_url(work),
+      work.identifier.first,
+      work.table_of_contents.first
+    ]
+  end
+
+  def add_files_to_bag(work)
+    work.file_sets.each do |file_set|
+      file_set.files.each do |file|
+        next if file.file_name.first.empty?
+        @bag.add_file("#{work.id}/#{file.file_name.first}") do |io|
+          io.set_encoding Encoding::BINARY
+          io.write file.content
+        end
+      end
+    end
+  end
+
+  def compress(tmp_dir)
+    zip_path = File.join(tmp_dir, "#{bag_name}.zip")
+    bag_dir  = @bag.bag_dir
+
+    Zip::File.open(zip_path, Zip::File::CREATE) do |zip|
+      Find.find(bag_dir) do |file|
+        relative_path = file.sub("#{tmp_dir}/", '')
+        zip.add(relative_path, file)
+      end
+    end
+
+    zip_path
+  end
+
+  def attach(zip_path)
+    File.open(zip_path) do |file|
+      @export.export_file.attach(
+        io: file,
+        filename: "#{bag_name}.zip",
+        content_type: 'application/zip'
+      )
+    end
+  end
+
+  def notify(success:)
+    return if @export.user.guest?
+    subject = success ? 'Export completed' : 'Export failed'
+    message = success ? success_message : failure_message
+    @export.user.send_message(@export.user, message, subject)
+  end
+
+  # rubocop:disable Rails/OutputSafety
+  def success_message
+    <<~MSG.html_safe
+      <div>
+        Your export (#{@export.id}) containing #{@export.items.count}
+        #{'item'.pluralize(@export.items.count)} is available for download at
+        <a href="#{Rails.application.routes.url_helpers.export_download_path(@export)}">
+          #{bag_name}.zip
+        </a>
+      </div>
+    MSG
+  end
+
+  def failure_message
+    <<~MSG.html_safe
+      <div>
+        Your export (#{@export.id}) failed with the following error:
+        <pre>#{ERB::Util.html_escape(@export.message)}</pre>
+      </div>
+    MSG
+  end
+  # rubocop:enable Rails/OutputSafety
+end

--- a/spec/jobs/export_job_spec.rb
+++ b/spec/jobs/export_job_spec.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExportJob, type: :job do
+  let(:admin) { FactoryBot.create(:admin) }
+
+  let(:pdf_file) do
+    File.open(file_fixture('pdf-sample.pdf')) { |file| create(:file_set, content: file) }
+  end
+
+  let(:test_time) { Time.zone.parse('2020-01-15T12:00:00Z') }
+
+  let(:publication) do
+    FactoryBot.create(:publication,
+           title: ['Test Publication'],
+           creator: ['Smith, Jane', 'Jones, Bob'],
+           corporate_name: ['Federal Reserve Bank of Minneapolis'],
+           date_created: ['2020-01-15'],
+           date_modified: test_time,
+           abstract: ['A test abstract'],
+           identifier: ['https://doi.org/10.21034/sr.999'],
+           table_of_contents: ['Chapter 1; Chapter 2'],
+           file_sets: [pdf_file])
+  end
+
+  let(:export) { FactoryBot.create(:export, user: admin, format: :bag, items: [publication.id]) }
+
+  before :all do
+    Hyrax::AdminSetCreateService.find_or_create_default_admin_set
+  end
+
+  after :all do
+    ActiveFedora::Cleaner.clean!
+  end
+
+  describe 'status lifecycle' do
+    it 'sets status to :completed on success', :aggregate_failures do
+      expect(export).to receive(:working!)
+      described_class.perform_now(export)
+      expect(export.reload.status).to eq 'completed'
+    end
+
+    it 'sets status to :failed with an error message when a work id cannot be found', :aggregate_failures do
+      export.update!(items: ['nonexistent_id'])
+      described_class.perform_now(export)
+      expect(export.reload.status).to eq 'failed'
+      expect(export.reload.message).to be_present
+    end
+
+    it 'sets status to :failed for unsupported work types', :aggregate_failures do
+      collection = Collection.new(
+        title: ['Test Collection'],
+        collection_type: Hyrax::CollectionType.find_or_create_default_collection_type
+).tap(&:save!)
+      export.update!(items: [collection.id])
+      described_class.perform_now(export)
+      expect(export.reload.status).to eq 'failed'
+      expect(export.reload.message).to match(/unsupported work type/i)
+    end
+  end
+
+  describe 'ActiveStorage attachment' do
+    it 'attaches the zip file to the export on success' do
+      described_class.perform_now(export)
+      expect(export.reload.export_file).to be_attached
+    end
+
+    context 'with invalid item IDs' do
+      let(:export) { FactoryBot.create(:export, user: admin, format: :bag, items: ['nonexistent_id']) }
+      it 'does not attach a file on failure' do
+        described_class.perform_now(export)
+        expect(export.reload.export_file).not_to be_attached
+      end
+    end
+  end
+
+  describe 'bag structure' do
+    it 'includes files for the work in the bag' do
+      described_class.perform_now(export)
+      expect(zip_entry_names(export)).to include(a_string_matching(publication.id))
+    end
+
+    it 'includes a SHA-256 manifest' do
+      described_class.perform_now(export)
+      expect(zip_entry_names(export)).to include(a_string_matching('manifest-sha256.txt'))
+    end
+
+    it 'includes a metadata CSV at the bag root' do
+      described_class.perform_now(export)
+      expect(zip_entry_names(export)).to include(a_string_matching('metadata.csv'))
+    end
+  end
+
+  describe 'metadata CSV' do
+    subject(:csv) { parsed_csv(export) }
+
+    before { described_class.perform_now(export) }
+
+    it 'includes the correct headers' do
+      expect(csv.headers).to eq ['title', 'name-creator', 'name-author', 'dateCreated',
+                                 'dateModified', 'abstract', 'location-url',
+                                 'identifier', 'tableOfContents']
+    end
+
+    it 'writes a row for the publication' do
+      expect(csv.length).to eq 1
+    end
+
+    it 'maps metadata', :aggregate_failures do
+      expect(csv[0].to_hash)
+        .to eq({
+                 # rubocop:disable Layout/HashAlignment
+                 'title' => 'Test Publication',
+                 'name-creator'    => 'Federal Reserve Bank of Minneapolis',
+                 'name-author'     => 'Jones, Bob|Smith, Jane',
+                 'dateCreated'     => '2020-01-15',
+                 'dateModified'    => '2020-01-15T12:00:00+00:00',
+                 'abstract'        => 'A test abstract',
+                 'location-url'    => "http://localhost:3000/concern/publications/#{publication.id}",
+                 'identifier'      => 'https://doi.org/10.21034/sr.999',
+                 'tableOfContents' => 'Chapter 1; Chapter 2'
+               })
+    end
+
+    context 'when items include multiple works' do
+      let(:publication2) { create(:publication, title: ['Second Publication']) }
+      let(:export) do
+        FactoryBot.create(:export, user: admin, format: :bag,
+                                   items: [publication.id, publication2.id])
+      end
+
+      it 'writes a row for each work' do
+        expect(csv.length).to eq 2
+      end
+    end
+  end
+
+  describe 'temporary file cleanup' do
+    it 'removes the temporary directory after success' do
+      tmp_dir = nil
+      allow(Dir).to receive(:mktmpdir).and_wrap_original do |original, *args, &block|
+        original.call(*args) do |dir|
+          tmp_dir = dir
+          block.call(dir)
+        end
+      end
+      described_class.perform_now(export)
+      expect(Dir.exist?(tmp_dir)).to be false
+    end
+
+    it 'removes the temporary directory after failure' do
+      tmp_dir = nil
+      allow(Dir).to receive(:mktmpdir).and_wrap_original do |original, *args, &block|
+        original.call(*args) do |dir|
+          tmp_dir = dir
+          block.call(dir)
+        end
+      end
+      export.update!(items: ['nonexistent_id'])
+      described_class.perform_now(export)
+      expect(Dir.exist?(tmp_dir)).to be false
+    end
+  end
+
+  describe 'user notification' do
+    context 'when the submitting user is an admin' do
+      it 'sends a success notification on completion' do
+        expect(admin).to receive(:send_message).with(
+          admin,
+          a_string_matching(/export/i),
+          a_string_matching(/completed/i)
+        )
+        described_class.perform_now(export)
+      end
+
+      it 'sends a failure notification on error' do
+        export.update!(items: ['nonexistent_id'])
+        expect(admin).to receive(:send_message).with(
+          admin,
+          a_string_matching(/export/i),
+          a_string_matching(/failed/i)
+        )
+        described_class.perform_now(export)
+      end
+    end
+
+    context 'when the submitting user is not an admin' do
+      let(:export) { FactoryBot.create(:export, user: User.system_user, format: :bag, items: [publication.id]) }
+
+      it 'does not send a notification' do
+        expect(User.system_user).not_to receive(:send_message)
+        described_class.perform_now(export)
+      end
+    end
+  end
+
+  private
+
+  def zip_entry_names(export)
+    export.reload
+    return [] unless export.export_file.attached?
+    Zip::File.open_buffer(export.export_file.download) do |zip|
+      return zip.map(&:name)
+    end
+  end
+
+  def parsed_csv(export)
+    export.reload
+    return CSV::Table.new([]) unless export.export_file.attached?
+    Zip::File.open_buffer(export.export_file.download) do |zip|
+      csv_entry = zip.find { |e| e.name.end_with?('metadata.csv') }
+      return CSV.parse(csv_entry.get_input_stream.read, headers: true)
+    end
+  end
+end


### PR DESCRIPTION
The new job accepts an `Export` object and creates a BagIt archive that inlcudes each of the works
corresponding to the identifiers in the `.items` array.