### PR TITLE
Add routing and controller support for BagIt exports

### DIFF
--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -14,6 +14,19 @@ class ExportsController < ApplicationController
     @exports = Export.all.order(created_at: :desc)
   end
 
+  # POST /admin/exports
+  def create
+    export_defaults = { user: current_user, format: :bag, status: :queued }
+    @export = Export.new(export_params.reverse_merge(export_defaults))
+    @export.items.compact_blank!
+    if @export.save
+      ExportJob.perform_later(@export)
+      redirect_to exports_path, notice: 'Export queued.'
+    else
+      redirect_back fallback_location: hyrax.dashboard_works_path, flash: { alert: 'Please select at least one item to export.' }
+    end
+  end
+
   # DELETE /admin/exports/:id
   def destroy
     @export.destroy
@@ -30,6 +43,10 @@ class ExportsController < ApplicationController
   end
 
   private
+
+  def export_params
+    params.require(:export).permit(:format, items: [])
+  end
 
   def render404
     render file: Rails.public_path.join('404.html'), status: :not_found, layout: 'hyrax/1_column'

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -17,6 +17,6 @@ class Ability
     return unless current_user.admin?
     can [:index], :reports
     can [:edit, :update, :create, :index, :show], Creator
-    can [:index, :destroy, :download], Export
+    can [:index, :create, :destroy, :download], Export
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
   post '/bag/create', to: 'bag#create'
 
   scope '/admin' do
-    resources :exports, only: [:index, :destroy]
+    resources :exports, only: [:index, :create, :destroy]
   end
   # Since export download links will be publicly accessible, we do not
   # want them nested under the admin namespace.

--- a/spec/requests/exports_request_spec.rb
+++ b/spec/requests/exports_request_spec.rb
@@ -151,4 +151,73 @@ RSpec.describe '/exports', type: :request do
       end
     end
   end
+
+  describe 'POST /admin/exports' do
+    let(:items) { ['abc123', 'def456'] }
+
+    context 'as an administrator' do
+      before { sign_in admin }
+
+      it 'creates an Export record' do
+        expect {
+          post exports_path, params: { export: { items: items } }
+        }.to change(Export, :count).by(1)
+      end
+
+      it 'sets the correct attributes on the export', :aggregate_failures do
+        post exports_path, params: { export: { items: items } }
+        export = Export.last
+        expect(export.items).to eq items
+        expect(export.format).to eq 'bag'
+        expect(export.user).to eq admin
+      end
+
+      it 'enqueues an ExportJob' do
+        expect {
+          post exports_path, params: { export: { items: items } }
+        }.to have_enqueued_job(ExportJob)
+      end
+
+      it 'redirects to the exports index' do
+        post exports_path, params: { export: { items: items } }
+        expect(response).to redirect_to(exports_path(locale: I18n.locale))
+      end
+
+      it 'sets a notice flash message' do
+        post exports_path, params: { export: { items: items } }
+        expect(flash[:notice]).to be_present
+      end
+
+      context 'when no items are selected' do
+        it 'does not create an Export record' do
+          expect {
+            post exports_path, params: { export: { items: [] } }
+          }.not_to change(Export, :count)
+        end
+
+        it 'redirects back with an alert' do
+          post exports_path, params: { export: { items: [] } },
+                             headers: { 'HTTP_REFERER' => hyrax.dashboard_works_path(locale: :en) }
+          expect(response).to redirect_to(hyrax.dashboard_works_path(locale: :en))
+          expect(flash[:alert]).to be_present
+        end
+      end
+    end
+
+    context 'as a regular user' do
+      before { sign_in user }
+
+      it 'returns not found' do
+        post exports_path, params: { export: { items: items } }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when not logged in' do
+      it 'returns not found' do
+        post exports_path, params: { export: { items: items } }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
 end

--- a/spec/routing/exports_routing_spec.rb
+++ b/spec/routing/exports_routing_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe ExportsController, type: :routing do
       expect(get: '/admin/exports').to route_to('exports#index')
     end
 
+    it 'routes POST /admin/exports to #create' do
+      expect(post: '/admin/exports').to route_to('exports#create')
+    end
+
     it 'routes DELETE /admin/exports/:id to #destroy' do
       expect(delete: '/admin/exports/1').to route_to('exports#destroy', id: '1')
     end
@@ -22,10 +26,6 @@ RSpec.describe ExportsController, type: :routing do
   describe 'does not provide' do
     it 'a route to #new' do
       expect(get: '/admin/exports/new').to route_to('pages#error_404', path: 'admin/exports/new')
-    end
-
-    it 'a route to #create' do
-      expect(post: '/admin/exports').to route_to('pages#error_404', path: 'admin/exports')
     end
 
     it 'a route to #show' do


### PR DESCRIPTION
This change adds the necessary routes and controller actions to allow administrators to submit new BagIt export jobs.