### PR TITLE
Add Export option to work actions in dashboard

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -1,0 +1,13 @@
+table.works-list {
+  form {
+    input.btn-link {
+      padding: 0;
+    }
+  }
+
+  li.divider {
+    margin: 0.5rem 1.5rem;
+    width: auto;
+    border-bottom: 1px solid #ccc;
+  }
+}

--- a/app/views/hyrax/my/_work_action_menu.html.erb
+++ b/app/views/hyrax/my/_work_action_menu.html.erb
@@ -1,0 +1,55 @@
+<div class="btn-group">
+  <% ul_id = "work-action-dropdown-ul-#{document.id}" %>
+  <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= document.id %>" aria-haspopup="true" aria-expanded="false" aria-controls="<%= ul_id %>">
+    <span class="sr-only"><%= t("hyrax.dashboard.my.sr.press_to") %> </span>
+    <%= t("hyrax.dashboard.my.action.select") %>
+  </button>
+
+  <ul role="menu" id="<%= ul_id %>" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= document.id %>">
+
+    <% if can? :edit, document.id %>
+      <li class="dropdown-item" role="menuitem" tabindex="-1">
+        <%= link_to [main_app, :edit, document],
+                    id: 'action-edit-work' do %>
+          <%= t("hyrax.dashboard.my.action.edit_work") %>
+        <% end %>
+      </li>
+    <% end %>
+
+    <% if can? :create, Export %>
+      <li class="dropdown-item" role="menuitem" tabindex="-1">
+        <%= button_to 'Create BagIt Export',
+                      main_app.exports_path,
+                      params: { export: { items: [document.id], format: :bag } },
+                      class: 'btn btn-link' %>
+      </li>
+    <% end %>
+
+    <li class="dropdown-item" role="menuitem" tabindex="-1">
+      <%= display_trophy_link(current_user, document.id) do |text| %>
+        <%= text %>
+      <% end %>
+    </li>
+
+    <% if can? :transfer, document.id %>
+      <li class="dropdown-item" role="menuitem" tabindex="-1">
+        <%= link_to(hyrax.new_work_transfer_path(document.id), id: 'action-transfer-work', class: 'itemicon itemtransfer', title: t("hyrax.dashboard.my.action.transfer")) do %>
+          <%= t("hyrax.dashboard.my.action.transfer") %>
+        <% end %>
+      </li>
+    <% end %>
+
+    <% if can? :edit, document.id %>
+      <li role="separator" class="divider"></li>
+      <li class="dropdown-item" role="menuitem" tabindex="-1">
+        <%= link_to [main_app, document],
+                    method: :delete,
+                    id: 'action-delete-work',
+                    data: {
+                      confirm: t("hyrax.dashboard.my.action.work_confirmation", application_name: application_name) } do %>
+          <%= t("hyrax.dashboard.my.action.delete_work") %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/spec/system/export_from_works_list_spec.rb
+++ b/spec/system/export_from_works_list_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'BagIt export from works list', type: :system, js: true do
+  let(:admin) { FactoryBot.create(:admin) }
+  let(:user) { FactoryBot.create(:user) }
+  let!(:publication) { create(:publication, title: ['Test Publication'], depositor: user.user_key) }
+
+  context 'as an admin user' do
+    before { login_as admin }
+
+    it 'shows the Create BagIt Export option in the Actions dropdown' do
+      visit hyrax.dashboard_works_path
+      within("tr#document_#{publication.id}") { click_on 'Select' }
+      expect(page).to have_button('Create BagIt Export')
+    end
+
+    it 'creates an Export record and redirects to the exports index' do
+      visit hyrax.dashboard_works_path
+      within("tr#document_#{publication.id}") { click_on 'Select' }
+      click_on 'Create BagIt Export'
+      expect(page).to have_current_path(main_app.exports_path(locale: I18n.locale))
+      expect(Export.last.items).to include(publication.id)
+    end
+
+    it 'enqueues an ExportJob' do
+      visit hyrax.dashboard_works_path
+      within("tr#document_#{publication.id}") { click_on 'Select' }
+      expect {
+        click_on 'Create BagIt Export'
+      }.to have_enqueued_job(ExportJob)
+    end
+  end
+
+  context 'as a non-admin user' do
+    before { login_as user }
+
+    it 'does not show the Create BagIt Export option' do
+      visit hyrax.my_works_path
+      within("tr#document_#{publication.id}") { click_on 'Select' }
+      expect(page).not_to have_button('Create BagIt Export')
+    end
+  end
+end

--- a/spec/views/hyrax/my/work_action_menu.html.erb_spec.rb
+++ b/spec/views/hyrax/my/work_action_menu.html.erb_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/my/_work_action_menu', type: :view do
+  let(:document) { SolrDocument.new(id: 'abc123') }
+
+  before do
+    allow(view).to receive(:can?).and_return(false)
+    allow(view).to receive(:main_app).and_return(main_app)
+    view.extend(Hyrax::TrophyHelper)
+    allow(view).to receive(:display_trophy_link).and_return(nil)
+  end
+
+  context 'for users with Export permissions' do
+    before do
+      allow(view).to receive(:can?).with(:create, Export).and_return(true)
+    end
+
+    it 'displays the Create BagIt Export button' do
+      render partial: 'hyrax/my/work_action_menu', locals: { document: document }
+      expect(rendered).to have_button('Create BagIt Export')
+    end
+
+    it 'submits to the exports path' do
+      render partial: 'hyrax/my/work_action_menu', locals: { document: document }
+      expect(rendered).to have_selector("form[action='#{main_app.exports_path}']")
+    end
+
+    it 'includes the work id as an item' do
+      render partial: 'hyrax/my/work_action_menu', locals: { document: document }
+      expect(rendered).to have_selector("input[name='export[items][]'][value='abc123']", visible: :hidden)
+    end
+  end
+
+  context 'for users without Export permissions' do
+    it 'does not display the Create BagIt Export button' do
+      render partial: 'hyrax/my/work_action_menu', locals: { document: document }
+      expect(rendered).not_to have_button('Create BagIt Export')
+    end
+  end
+end


### PR DESCRIPTION
This change adds an action to the work-level dropdown in dashboard work lists that allows admins to export a work to a BagIt bag.

We also re-ordered the action list to put delete at the bottom of the list with extra spacing around the delete option to make it more difficult to accidentally click the "Delete" option.

| **BEFORE** | **AFTER** |
|-------------|------------|
| <img width="300" height="296" alt="image" src="https://github.com/user-attachments/assets/37ed05cd-5a65-4007-b869-42a831f98a05" />|<img width="308" height="295" alt="image" src="https://github.com/user-attachments/assets/54948809-cb4c-4233-a4dc-89778eb45f63" />|