### PR TITLE
Ensure Export items are always in a canonical order

### DIFF
--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -16,14 +16,27 @@ class ExportsController < ApplicationController
 
   # POST /admin/exports
   def create
-    export_defaults = { user: current_user, format: :bag, status: :queued }
-    @export = Export.new(export_params.reverse_merge(export_defaults))
-    @export.items.compact_blank!
-    if @export.save
-      ExportJob.perform_later(@export)
+    export = Export.new(export_params.reverse_merge(format: :bag, user: current_user))
+    if export.items.empty?
+      redirect_back_or_to hyrax.dashboard_works_path, allow_other_host: false, alert: 'Please select one or more items to export.'
+      return
+    end
+
+    existing = Export.order(updated_at: :desc).find_by(items: export.items, format: export.format)
+    case existing&.status
+    when 'queued', 'working'
+      redirect_to exports_path, alert: 'An export with those items is already queued, please wait for it to complete.'
+      return
+    when 'completed'
+      redirect_to exports_path, alert: 'An export with those items already exists and is available for download.'
+      return
+    end
+
+    if export.save
+      ExportJob.perform_later(export)
       redirect_to exports_path, notice: 'Export queued.'
     else
-      redirect_back fallback_location: hyrax.dashboard_works_path, flash: { alert: 'Please select at least one item to export.' }
+      redirect_back_or_to hyrax.dashboard_works_path, alert: "Your request could not be processed.\n\n#{export.errors.full_messages.join("\n- ")}"
     end
   end
 

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -9,6 +9,8 @@ class ExportJob < ApplicationJob
 
   SUPPORTED_TYPES = [Publication, Dataset, ConferenceProceeding].freeze
 
+  after_enqueue { |job| job.arguments.first.queued! }
+
   def perform(export)
     @export = export
     @export.working!

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -9,6 +9,9 @@ class Export < ApplicationRecord
   validates :format, presence: true
   validates :items, length: { minimum: 1 }
 
+  # Always uses a canonicalized array of items
+  normalizes :items, with: ->(value) { Array(value).compact_blank.uniq.sort }
+
   def base_name
     base = "#{Rails.application.config.bag_prefix}_#{format}_#{items.first}"
     collisions = ActiveStorage::Blob.where("filename LIKE ?", base + '%').count

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,10 @@ module Cypripedium
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
+    # Explicitly set AR Marshalling to support normalization
+    # see: https://api.rubyonrails.org/v7.1/classes/ActiveRecord/Normalization/ClassMethods.html#method-i-normalizes
+    config.active_record.marshalling_format_version = 7.1
+
     config.active_job.queue_adapter = :sidekiq
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/spec/jobs/export_job_spec.rb
+++ b/spec/jobs/export_job_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe ExportJob, type: :job do
   end
 
   describe 'status lifecycle' do
+    it 'sets status to :queued on when queued', :aggregate_failures do
+      expect(export.status).to eq 'unknown'
+      described_class.perform_later(export)
+      expect(export.reload.status).to eq 'queued'
+    end
+
     it 'sets status to :completed on success', :aggregate_failures do
       expect(export).to receive(:working!)
       described_class.perform_now(export)

--- a/spec/models/export_spec.rb
+++ b/spec/models/export_spec.rb
@@ -46,10 +46,19 @@ RSpec.describe Export, type: :model do
       expect(export.items).to be_an Array
     end
 
-    it 'accepts an array of id strings' do
-      export.items = ['abc123', 'def456']
-      export.save!
-      expect(export.reload.items).to eq ['abc123', 'def456']
+    it 'sorts and deduplicates on assignment' do
+      export = build(:export, items: ['zzz', 'aaa', 'abc', 'aaa'])
+      expect(export.items).to eq ['aaa', 'abc', 'zzz']
+    end
+
+    it 'removes blank items' do
+      export = build(:export, items: ['789', nil, '123', 'atoz', '', 'abc'])
+      expect(export.items).to eq ['123', '789', 'abc', 'atoz']
+    end
+
+    it 'persists as a sorted and deduplicated list' do
+      export = create(:export, items: ['zzz', 'aaa', 'abc', 'aaa'])
+      expect(export.reload.items).to eq ['aaa', 'abc', 'zzz']
     end
   end
 

--- a/spec/requests/exports_request_spec.rb
+++ b/spec/requests/exports_request_spec.rb
@@ -153,40 +153,10 @@ RSpec.describe '/exports', type: :request do
   end
 
   describe 'POST /admin/exports' do
-    let(:items) { ['abc123', 'def456'] }
+    let(:items) { ['def456', 'abc123'] }
 
     context 'as an administrator' do
       before { sign_in admin }
-
-      it 'creates an Export record' do
-        expect {
-          post exports_path, params: { export: { items: items } }
-        }.to change(Export, :count).by(1)
-      end
-
-      it 'sets the correct attributes on the export', :aggregate_failures do
-        post exports_path, params: { export: { items: items } }
-        export = Export.last
-        expect(export.items).to eq items
-        expect(export.format).to eq 'bag'
-        expect(export.user).to eq admin
-      end
-
-      it 'enqueues an ExportJob' do
-        expect {
-          post exports_path, params: { export: { items: items } }
-        }.to have_enqueued_job(ExportJob)
-      end
-
-      it 'redirects to the exports index' do
-        post exports_path, params: { export: { items: items } }
-        expect(response).to redirect_to(exports_path(locale: I18n.locale))
-      end
-
-      it 'sets a notice flash message' do
-        post exports_path, params: { export: { items: items } }
-        expect(flash[:notice]).to be_present
-      end
 
       context 'when no items are selected' do
         it 'does not create an Export record' do
@@ -199,7 +169,84 @@ RSpec.describe '/exports', type: :request do
           post exports_path, params: { export: { items: [] } },
                              headers: { 'HTTP_REFERER' => hyrax.dashboard_works_path(locale: :en) }
           expect(response).to redirect_to(hyrax.dashboard_works_path(locale: :en))
-          expect(flash[:alert]).to be_present
+          expect(flash[:alert]).to match(/select one or more/i)
+        end
+      end
+
+      context 'when a queued or working export with the same items and format exists' do
+        it 'does not create a new Export record' do
+          create(:export, format: :bag, items: items, status: :queued)
+          expect {
+            post exports_path, params: { export: { items: items } }
+          }.not_to change(Export, :count)
+        end
+
+        it 'redirects to the index with an alert' do
+          create(:export, format: :bag, items: items, status: :working)
+          post exports_path, params: { export: { items: items } }
+          expect(response).to redirect_to(exports_path(locale: I18n.locale))
+          expect(flash[:alert]).to match(/already queued/i)
+        end
+      end
+
+      context 'when a completed export with the same items and format exists' do
+        before { create(:export, format: :bag, items: items, status: :completed) }
+
+        it 'does not create a new Export record' do
+          expect {
+            post exports_path, params: { export: { items: items } }
+          }.not_to change(Export, :count)
+        end
+
+        it 'redirects to the index with an alert', :aggregate_failures do
+          post exports_path, params: { export: { items: items } }
+          expect(response).to redirect_to(exports_path(locale: I18n.locale))
+          expect(flash[:alert]).to match(/already exists/i)
+        end
+      end
+
+      context 'when no blocking export exists' do
+        it 'creates an Export record' do
+          expect {
+            post exports_path, params: { export: { items: items } }
+          }.to change(Export, :count).by(1)
+        end
+
+        it 'stores items in canonical order', :aggregate_failures do
+          post exports_path, params: { export: { items: items } }
+          new_export = Export.last
+          expect(new_export.items).to eq ['abc123', 'def456'] # canonical order
+          expect(new_export.format).to eq 'bag' # defaults to bag
+          expect(new_export.user).to eq admin # defaults to current user
+          expect(new_export.status).to eq 'queued' # set when queued
+        end
+
+        it 'enqueues an ExportJob' do
+          expect {
+            post exports_path, params: { export: { items: items } }
+          }.to have_enqueued_job(ExportJob)
+        end
+
+        it 'redirects to the exports index with a notice' do
+          post exports_path, params: { export: { items: items } }
+          expect(response).to redirect_to(exports_path(locale: I18n.locale))
+          expect(flash[:notice]).to be_present
+        end
+      end
+
+      context 'when a failed export with the same items and format exists' do
+        before { create(:export, format: :bag, items: items, status: :failed) }
+
+        it 'creates a new Export record' do
+          expect {
+            post exports_path, params: { export: { items: items } }
+          }.to change(Export, :count).by(1)
+        end
+
+        it 'enqueues an ExportJob' do
+          expect {
+            post exports_path, params: { export: { items: items } }
+          }.to have_enqueued_job(ExportJob)
         end
       end
     end


### PR DESCRIPTION
**ISSUE**
We want to ensure that we can detect and deduplicate identical Export requests so that we don't unintentionally rebuild existing bags.

**RESOLUTION**
* Normalize the `#items` attribute so that we can always assume the list of items for any `Export` is deduplicated and sorted.
* Add controller logic to detect potential duplication and alert the user
* Refactor controller, job, and model logic for improved clarity