### PR TITLE
Allow admins to delete Export records

### DIFF
--- a/app/views/exports/index.html.erb
+++ b/app/views/exports/index.html.erb
@@ -14,12 +14,13 @@
       <th class="file">File</th>
       <th class="item_count">Item Count</th>
       <th class="message">Message</th>
+      <th class="actions">Actions</th>
     </tr>
     </thead>
 
     <tbody>
     <% @exports.each_with_index do |export, index| %>
-      <tr>
+      <tr id="<%= dom_id(export) -%>">
         <td class="id"><%= export.id -%></td>
         <td class="timestamp" data-sort=<%= index %> ><%= export.updated_at.to_fs(:db) -%></td>
         <td class="status #{export.status}"><%= export.status -%></td>
@@ -28,6 +29,11 @@
         <td class="file"><%= link_to(export.export_file.filename, export_download_path(export), download: export.export_file.filename) if export.export_file.attached? -%></td>
         <td class="item_count"><%= export.items.count -%></td>
         <td class="message"><%= export.message -%></td>
+        <td class="actions">
+          <% unless export.queued? || export.working? %>
+            <%= button_to 'Delete', export_path(export), method: :delete, class: 'btn btn-danger btn-sm' %>
+          <% end %>
+        </td>
       </tr>
     <% end %>
     </tbody>

--- a/spec/views/exports/index.html.erb_spec.rb
+++ b/spec/views/exports/index.html.erb_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'exports/index', type: :view do
+  let(:admin) { create(:admin) }
+
+  let(:completed_export) { create(:export, user: admin, format: :bag, items: ['abc123'], status: :completed) }
+  let(:failed_export)    { create(:export, user: admin, format: :bag, items: ['def456'], status: :failed) }
+  let(:queued_export)    { create(:export, user: admin, format: :bag, items: ['ghi789'], status: :queued) }
+  let(:working_export)   { create(:export, user: admin, format: :bag, items: ['jkl012'], status: :working) }
+
+  before do
+    assign(:exports, [completed_export, failed_export, queued_export, working_export])
+    allow(view).to receive(:main_app).and_return(main_app)
+  end
+
+  it 'renders a row for each export' do
+    render
+    expect(rendered).to have_selector('tbody tr', count: 4)
+  end
+
+  it 'has a download link for completed exports' do
+    render
+    within("tr#export_#{completed_export.id}") do
+      expect(rendered).to have_link(href: download_export_path(completed_export))
+    end
+  end
+
+  it 'includes an actions column header' do
+    render
+    expect(rendered).to have_selector('th.actions')
+  end
+
+  it 'shows a delete link for completed exports' do
+    render
+    within("tr#export_#{completed_export.id}") do
+      expect(rendered).to have_button('Delete')
+    end
+  end
+
+  it 'shows a delete link for failed exports' do
+    render
+    within("tr#export_#{failed_export.id}") do
+      expect(rendered).to have_button('Delete')
+    end
+  end
+
+  it 'does not show a delete link for queued exports' do
+    render
+    within("tr#export_#{queued_export.id}") do
+      expect(rendered).not_to have_button('Delete')
+    end
+  end
+
+  it 'does not show a delete link for working exports' do
+    render
+    within("tr#export_#{working_export.id}") do
+      expect(rendered).not_to have_button('Delete')
+    end
+  end
+
+  it 'delete link submits to the correct path' do
+    render
+    expect(rendered).to have_selector(
+                          "form[action='#{main_app.export_path(completed_export)}'][method='post']"
+                        )
+  end
+end


### PR DESCRIPTION
This change adds a button to the Exports index page that allows admins to delete existing Export records.