### PR TITLE
[Refactor] Clean up Request test locale settings

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,6 +75,11 @@ RSpec.configure do |config|
   config.append_after do
     DatabaseCleaner.clean
   end
+
+  config.before(:each, type: :request) do
+    default_url_options[:locale] = :en
+  end
+
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/requests/creators_spec.rb
+++ b/spec/requests/creators_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "/creators", type: :request, clean: true do
 
       it "redirects to the created creator" do
         post creators_url, params: { creator: valid_attributes }
-        expect(response).to redirect_to(creator_url(Creator.last) + "?locale=en")
+        expect(response).to redirect_to(creator_url(Creator.last))
       end
     end
 
@@ -107,7 +107,7 @@ RSpec.describe "/creators", type: :request, clean: true do
         creator = Creator.create! valid_attributes
         patch creator_url(creator), params: { creator: new_attributes }
         creator.reload
-        expect(response).to redirect_to(creator_url(creator) + "?locale=en")
+        expect(response).to redirect_to(creator_url(creator))
       end
     end
 

--- a/spec/requests/exports_request_spec.rb
+++ b/spec/requests/exports_request_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe '/exports', type: :request do
 
       it 'redirects to the index' do
         delete export_path(export)
-        expect(response).to redirect_to(exports_path(locale: I18n.locale))
+        expect(response).to redirect_to(exports_path)
       end
     end
 
@@ -208,8 +208,8 @@ RSpec.describe '/exports', type: :request do
 
         it 'redirects back with an alert' do
           post exports_path, params: { export: { items: [] } },
-                             headers: { 'HTTP_REFERER' => hyrax.dashboard_works_path(locale: :en) }
-          expect(response).to redirect_to(hyrax.dashboard_works_path(locale: :en))
+                             headers: { 'HTTP_REFERER' => hyrax.dashboard_works_path }
+          expect(response).to redirect_to(hyrax.dashboard_works_path)
           expect(flash[:alert]).to match(/select one or more/i)
         end
       end
@@ -225,7 +225,7 @@ RSpec.describe '/exports', type: :request do
         it 'redirects to the index with an alert' do
           create(:export, format: :bag, items: items, status: :working)
           post exports_path, params: { export: { items: items } }
-          expect(response).to redirect_to(exports_path(locale: I18n.locale))
+          expect(response).to redirect_to(exports_path)
           expect(flash[:alert]).to match(/already queued/i)
         end
       end
@@ -241,7 +241,7 @@ RSpec.describe '/exports', type: :request do
 
         it 'redirects to the index with an alert', :aggregate_failures do
           post exports_path, params: { export: { items: items } }
-          expect(response).to redirect_to(exports_path(locale: I18n.locale))
+          expect(response).to redirect_to(exports_path)
           expect(flash[:alert]).to match(/already exists/i)
         end
       end
@@ -270,7 +270,7 @@ RSpec.describe '/exports', type: :request do
 
         it 'redirects to the exports index with a notice' do
           post exports_path, params: { export: { items: items } }
-          expect(response).to redirect_to(exports_path(locale: I18n.locale))
+          expect(response).to redirect_to(exports_path)
           expect(flash[:notice]).to be_present
         end
       end

--- a/spec/requests/publication_request_spec.rb
+++ b/spec/requests/publication_request_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "/concern/publications", type: :request, clean: true do
 
       it "redirects to the created publication" do
         post hyrax_publications_url, params: { publication: valid_attributes }
-        expect(response).to redirect_to(hyrax_publication_url(Publication.last) + "?locale=en")
+        expect(response).to redirect_to(hyrax_publication_url(Publication.last))
       end
     end
   end
@@ -87,7 +87,7 @@ RSpec.describe "/concern/publications", type: :request, clean: true do
         publication = Publication.create! valid_attributes
         patch hyrax_publication_url(publication), params: { publication: new_attributes }
         publication.reload
-        expect(response).to redirect_to(hyrax_publication_url(publication) + "?locale=en")
+        expect(response).to redirect_to(hyrax_publication_url(publication))
       end
     end
   end

--- a/spec/requests/reports_request_spec.rb
+++ b/spec/requests/reports_request_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "/reports", type: :request do
 
         # Authorization failures currently default to redirecting to the sign-in page
         # see Hydra::Controller::ControllerBehavior#deny_access
-        expect(response).to redirect_to(new_user_session_path(locale: I18n.locale))
+        expect(response).to redirect_to(new_user_session_path)
       end
     end
 

--- a/spec/system/creator_spec.rb
+++ b/spec/system/creator_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe 'Creators', :aggregate_failures, type: :system, js: true do
   let(:creator_with_alternates) { Creator.create!(display_name: "Allen, Stephen G.", alternate_names: ["Allen, S. Gomes", "Aliens, Steve"]) }
   let(:inactive_creator) { Creator.create!(display_name: "Milk, The Small", active_creator: false, repec: '12345') }
 
-  before do
+  before :all do
     @initial_locale = default_url_options[:locale]
     default_url_options[:locale] = I18n.default_locale
   end
 
-  after do
+  after :all do
     default_url_options[:locale] = @initial_locale
   end
 

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe 'dashboard', js: true do
   context 'for guest users' do
     it 'redirects to login' do
       logout
-      visit('dashboard')
-      expect(page).to have_current_path(new_user_session_path)
+      visit('/dashboard')
+      expect(page).to have_current_path(new_user_session_path(locale: nil))
     end
   end
 
@@ -22,7 +22,7 @@ RSpec.describe 'dashboard', js: true do
     end
 
     it 'has a works section' do
-      expect(page).to have_link('Works', href: '/dashboard/my/works?locale=en')
+      expect(page).to have_link('Works', href: %r{/dashboard/my/works})
     end
 
     it 'restricts admin-only menus' do
@@ -49,7 +49,7 @@ RSpec.describe 'dashboard', js: true do
     it 'allows Hyrax controllers to access Cypripedium paths' do
       login_as admin
       expect { visit('dashboard/my/works') }.not_to raise_exception
-      expect(page).to have_link(href: reports_path(locale: I18n.locale))
+      expect(page).to have_link(href: reports_path)
     end
   end
 end

--- a/spec/system/new_work_workflow_spec.rb
+++ b/spec/system/new_work_workflow_spec.rb
@@ -39,10 +39,10 @@ RSpec.describe 'New work creation', type: :system, js: true do
     page.has_selector?(id: 'with_files_submit') until page.has_selector?('.work-title-wrapper span[itemprop="name"]')
 
     # The page should redirect to the newly created Publication
-    expect(current_path).to match(hyrax_publication_path(Publication.last))
+    expect(current_path).to include(hyrax_publication_path(Publication.last, locale: nil))
     expect(page).to have_content('My new Publication')
     expect(page).to have_selector('span.badge', text: 'Public')
     edit_link = page.find_link('Edit')['href']
-    expect(edit_link).to match edit_hyrax_publication_path(Publication.last)
+    expect(edit_link).to include(edit_hyrax_publication_path(Publication.last, locale: nil))
   end
 end


### PR DESCRIPTION
This commit ensures that Request tests have a consistent locale setting so we do not have to explicity add it to paths for comparison.

It also updates some System tests to ensure path comparisions are more consistent to avoid flaky tests.