### PR TITLE
List Exports in most-recent-first order

### DIFF
--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -11,7 +11,7 @@ class ExportsController < ApplicationController
     add_breadcrumb t(:'hyrax.controls.home'), root_path
     add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
     add_breadcrumb t(:'dashboard.breadcrumbs.admin.exports')
-    @exports = Export.all.order(created_at: :desc)
+    @exports = @exports.reorder(id: :desc)
   end
 
   # POST /admin/exports

--- a/app/views/exports/index.html.erb
+++ b/app/views/exports/index.html.erb
@@ -21,16 +21,16 @@
     <tbody>
     <% @exports.each_with_index do |export, index| %>
       <tr id="<%= dom_id(export) -%>">
-        <td class="id">
+        <td class="id" data-sort="<%= index %>" >
           <a href="#"
              data-toggle="modal"
              data-target="#items-modal"
              data-items-url="<%= items_export_path(export) %>"
              aria-label="Show <%= export.items.count %> included items">
-            <%= export.id %> <span class="fa fa-circle-info" aria-hidden="true"></span>
+            <%= export.id %>
           </a>
         </td>
-        <td class="timestamp" data-sort=<%= index %> ><%= export.updated_at.to_fs(:db) -%></td>
+        <td class="timestamp" data-sort=<%= export.updated_at.to_i %> ><%= export.updated_at.to_fs(:db) -%></td>
         <td class="status <%= export.status %>"><%= export.status -%></td>
         <td class="user"><%= export.user.display_name -%></td>
         <td class="format"><%= export.format -%></td>
@@ -43,7 +43,7 @@
             <%= export.items.count %> <span class="fa fa-circle-info" aria-hidden="true"></span>
           </a>
         </td>
-        <td class="file"><%= link_to(export.export_file.filename, export_download_path(export), download: export.export_file.filename) if export.export_file.attached? -%></td>
+        <td class="file"><%= link_to(export.export_file.filename, export_download_path(export, locale: nil), download: export.export_file.filename) if export.export_file.attached? -%></td>
         <td class="message"><%= export.message -%></td>
         <td class="actions">
           <% unless export.queued? || export.working? %>

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -48,8 +48,9 @@ RSpec.describe 'dashboard', js: true do
     # don't access tenejo routes as expected
     it 'allows Hyrax controllers to access Cypripedium paths' do
       login_as admin
-      expect { visit('dashboard/my/works') }.not_to raise_exception
-      expect(page).to have_link(href: reports_path)
+      visit('dashboard/my/works')
+      # Hyrax controllers should render sidebar with main app links
+      expect(page).to have_link(id: 'dashboard-sidebar-reports', href: /reports/)
     end
   end
 end

--- a/spec/views/exports/index.html.erb_spec.rb
+++ b/spec/views/exports/index.html.erb_spec.rb
@@ -10,14 +10,26 @@ RSpec.describe 'exports/index', type: :view do
   let(:queued_export)    { create(:export, user: admin, format: :bag, items: ['ghi789'], status: :queued) }
   let(:working_export)   { create(:export, user: admin, format: :bag, items: ['jkl012'], status: :working) }
 
+  let(:exports) { [completed_export, failed_export, queued_export, working_export] }
+
   before do
-    assign(:exports, [completed_export, failed_export, queued_export, working_export])
+    # Mimic an ActiveRecord relation orderd by id in descending order
+    assign(:exports, exports.sort_by(&:id).reverse)
     allow(view).to receive(:main_app).and_return(main_app)
   end
 
   it 'renders a row for each export' do
     render
     expect(rendered).to have_selector('tbody tr', count: 4)
+  end
+
+  it 'includes a data-sort attribute on ids', :aggregate_failures do
+    render
+    # `data-sort` attributes should be in inverse order of the export order in the assigns
+    expect(rendered).to have_selector("td.id[data-sort=0]", text: working_export.id)
+    expect(rendered).to have_selector("td.id[data-sort=1]", text: queued_export.id)
+    expect(rendered).to have_selector("td.id[data-sort=2]", text: failed_export.id)
+    expect(rendered).to have_selector("td.id[data-sort=3]", text: completed_export.id)
   end
 
   it 'has a download link for completed exports' do


### PR DESCRIPTION
**ISSUE**
We're usually interested in seeing the most recent (or some recent) Export more than very old Exports. So, we'd like the list to be sorted by ID descending, instead of having to scroll to the bottom of the list.

**RESOLUTION**
This change adds a hidden sort index to the ID column to ensure that the most recent exports are displayed at the top of the index view when the page initially loads.

**NOTE:** This change also fixes a flaky dashboard spec.