### PR TITLE
Refine export Items pop-up layout

### DIFF
--- a/app/assets/stylesheets/exports.scss
+++ b/app/assets/stylesheets/exports.scss
@@ -34,18 +34,26 @@
 }
 
 #items-modal {
+  .modal-dialog {
+    max-width: 50rem;
+  }
   .modal-content {
     border-radius: 1rem;
   }
 
   .id {
-    display: inline-block;
-    width: 6.5rem;
+    flex: 0 0 6.5rem;
   }
+
   .title {
+    flex: 0 0 40rem;
+    padding-left: 2rem;
+    text-indent: -1rem;
+
     &::before {
-      content: " \2014 ";
-      margin-right: 1.5rem;
+      content: "\2014 "; // em dash
+      display: inline-flex;
+      width: 1rem;
     }
   }
 }

--- a/app/views/exports/_items.html.erb
+++ b/app/views/exports/_items.html.erb
@@ -5,7 +5,7 @@ created: <%= export.created_at.strftime("%Y-%m-%d %H:%M:%S") %>
 <ul class="list-unstyled mt-4 mb-0 border-top">
   <% docs.each do |doc| %>
     <% item_link = work_path(doc) %>
-    <li class="py-1 border-bottom" id="<%= dom_id(doc) %>">
+    <li class="py-1 border-bottom d-flex" id="<%= dom_id(doc) %>">
       <span class="id"><%= link_to_if item_link, doc.id, item_link, target: '_blank', rel: 'noopener noreferrer' %></span>
       <span class="title"><%= doc.title.first || content_tag(:em, "Item not available") %></span>
     </li>


### PR DESCRIPTION
* Give 'id' and 'title' columns fixed width
* Wrap long titles
<img width="710" height="469" alt="image" src="https://github.com/user-attachments/assets/5485811b-40f5-4187-b3a7-dbef93229501" />
