### PR TITLE
Export each work's metata to a JSON tag file in the Bag

### DIFF
--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -78,6 +78,17 @@ class ExportJob < ApplicationJob
   end
 
   def add_files_to_bag(work)
+    # serialize the work's metadata to a JSON file in the metadata tag directory
+    @bag.add_tag_file("metadata/#{work.id}.json") do |io|
+      json = ::ApplicationController.render(
+        template: 'hyrax/base/show',
+        formats: [:json],
+        assigns: { curation_concern: work, presenter: Hyrax::WorkShowPresenter.new(SolrDocument.new(work.to_solr), nil) }
+      )
+      io.write json
+    end
+
+    # add the work's files to the bag
     work.file_sets.each do |file_set|
       file_set.files.each do |file|
         next if file.file_name.first.empty?


### PR DESCRIPTION
This change adds a `/metadata` folder to the bag. Each file in the folder contains any metadata for the work with the same ID.

Metadata is serialized in JSON format.

<img width="489" height="267" alt="image" src="https://github.com/user-attachments/assets/671880ff-ee71-48dc-b002-c2e1d4b5b0ae" />
