### PR TITLE
Update the Exports UI to de-emphasize errors

### DIFF
--- a/app/assets/stylesheets/exports.scss
+++ b/app/assets/stylesheets/exports.scss
@@ -1,24 +1,4 @@
 #exports {
-  .id {
-    max-width: 3rem;
-    text-align: right;
-  }
-  .timestamp { max-width: 10rem; }
-  .actions { text-align: right; }
-
-  .item_count {
-    max-width: 3rem;
-    text-align: center;
-    a {
-      text-decoration: none;
-
-      ::after {
-        font-family: 'FontAwesome';
-        content: '\f05a'; // fa-info-circle
-        margin-left: 0.25rem;
-      }
-    }
-  }
 
   .status {
     color: black;
@@ -28,8 +8,31 @@
     &.queued { color: var(--frbm-pirate-gold); }
   }
 
-  .format {
-    max-width: 3rem;
+  table {
+    .id {
+      max-width: 3rem;
+      text-align: right;
+    }
+    .timestamp { max-width: 10rem; }
+    .actions { text-align: right; }
+
+    .item_count {
+      max-width: 3rem;
+      text-align: center;
+      a {
+        text-decoration: none;
+
+        ::after {
+          font-family: 'FontAwesome';
+          content: '\f05a'; // fa-info-circle
+          margin-left: 0.25rem;
+        }
+      }
+    }
+
+    .format {
+      max-width: 3rem;
+    }
   }
 }
 
@@ -54,6 +57,14 @@
       content: "\2014 "; // em dash
       display: inline-flex;
       width: 1rem;
+    }
+  }
+
+  #export-message {
+    margin-top: 2rem;
+
+    h4.status {
+      padding: 0;
     }
   }
 }

--- a/app/views/exports/_items.html.erb
+++ b/app/views/exports/_items.html.erb
@@ -11,3 +11,10 @@ created: <%= export.created_at.strftime("%Y-%m-%d %H:%M:%S") %>
     </li>
   <% end %>
 </ul>
+
+<% if export.message.present? %>
+  <div id="export-message">
+    <h4 class="status <%= export.status%>" ><%= export.status.capitalize %></h4>
+    <pre><%= export.message %></pre>
+  </div>
+<% end %>

--- a/app/views/exports/index.html.erb
+++ b/app/views/exports/index.html.erb
@@ -2,81 +2,81 @@
   <h1><span class="fa fa-archive" aria-hidden="true"></span>Exported Archive Files</h1>
 <% end %>
 
-<div class="table-responsive">
-  <table id='exports' class='table table-striped table-bordered datatable' >
-    <thead>
-    <tr>
-      <th class="id">ID</th>
-      <th class="timestamp">Processed</th>
-      <th class="status">Status</th>
-      <th class="user">Submitted by</th>
-      <th class="format">Format</th>
-      <th class="item_count">Items</th>
-      <th class="file">File</th>
-      <th class="message">Message</th>
-      <th class="actions">Actions</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    <% @exports.each_with_index do |export, index| %>
-      <tr id="<%= dom_id(export) -%>">
-        <td class="id" data-sort="<%= index %>" >
-          <a href="#"
-             data-toggle="modal"
-             data-target="#items-modal"
-             data-items-url="<%= items_export_path(export) %>"
-             aria-label="Show <%= export.items.count %> included items">
-            <%= export.id %>
-          </a>
-        </td>
-        <td class="timestamp" data-sort=<%= export.updated_at.to_i %> ><%= export.updated_at.to_fs(:db) -%></td>
-        <td class="status <%= export.status %>"><%= export.status -%></td>
-        <td class="user"><%= export.user.display_name -%></td>
-        <td class="format"><%= export.format -%></td>
-        <td class="item_count" data-search="<%= export.items.join(' ') %>">
-          <a href="#"
-             data-toggle="modal"
-             data-target="#items-modal"
-             data-items-url="<%= items_export_path(export) %>"
-             aria-label="Show <%= export.items.count %> included items">
-            <%= export.items.count %> <span class="fa fa-circle-info" aria-hidden="true"></span>
-          </a>
-        </td>
-        <td class="file"><%= link_to(export.export_file.filename, export_download_path(export, locale: nil), download: export.export_file.filename) if export.export_file.attached? -%></td>
-        <td class="message"><%= export.message -%></td>
-        <td class="actions">
-          <% unless export.queued? || export.working? %>
-            <%= button_to export_path(export), method: :delete, class: 'btn btn-danger btn-sm' do %>
-              Delete
-              <span class="fa fa-trash-o" aria-hidden="true"></span>
-            <% end %>
-          <% end %>
-        </td>
+<div id='exports'>
+  <div class="table-responsive">
+    <table class='table table-striped table-bordered datatable' >
+      <thead>
+      <tr>
+        <th class="id">ID</th>
+        <th class="timestamp">Processed</th>
+        <th class="status">Status</th>
+        <th class="user">Submitted by</th>
+        <th class="format">Format</th>
+        <th class="item_count">Items</th>
+        <th class="file">File</th>
+        <th class="actions">Actions</th>
       </tr>
-    <% end %>
-    </tbody>
-  </table>
-</div>
+      </thead>
 
-<div class="modal fade" id="items-modal" tabindex="-1" role="dialog" aria-labelledby="items-modal-label" aria-hidden="true">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h2 class="modal-title" id="items-modal-label">Export Details</h2>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
-      <div class="modal-body">
-        <div id="items-modal-spinner" class="text-center">
-          <span class="fa fa-spinner fa-spin fa-2x" aria-hidden="true"></span>
-          <span class="sr-only">Loading...</span>
+      <tbody>
+      <% @exports.each_with_index do |export, index| %>
+        <tr id="<%= dom_id(export) -%>">
+          <td class="id" data-sort="<%= index %>" >
+            <a href="#"
+               data-toggle="modal"
+               data-target="#items-modal"
+               data-items-url="<%= items_export_path(export) %>"
+               aria-label="Show <%= export.items.count %> included items">
+              <%= export.id %>
+            </a>
+          </td>
+          <td class="timestamp" data-sort=<%= export.updated_at.to_i %> ><%= export.updated_at.to_fs(:db) -%></td>
+          <td class="status <%= export.status %>"><%= export.status -%></td>
+          <td class="user"><%= export.user.display_name -%></td>
+          <td class="format"><%= export.format -%></td>
+          <td class="item_count" data-search="<%= export.items.join(' ') %>">
+            <a href="#"
+               data-toggle="modal"
+               data-target="#items-modal"
+               data-items-url="<%= items_export_path(export) %>"
+               aria-label="Show <%= export.items.count %> included items">
+              <%= export.items.count %> <span class="fa fa-circle-info" aria-hidden="true"></span>
+            </a>
+          </td>
+          <td class="file"><%= link_to(export.export_file.filename, export_download_path(export, locale: nil), download: export.export_file.filename) if export.export_file.attached? -%></td>
+          <td class="actions">
+            <% unless export.queued? || export.working? %>
+              <%= button_to export_path(export), method: :delete, class: 'btn btn-danger btn-sm' do %>
+                Delete
+                <span class="fa fa-trash-o" aria-hidden="true"></span>
+              <% end %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="modal fade" id="items-modal" tabindex="-1" role="dialog" aria-labelledby="items-modal-label" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2 class="modal-title" id="items-modal-label">Export Details</h2>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
         </div>
-        <div id="items-modal-content" class="d-none"></div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        <div class="modal-body">
+          <div id="items-modal-spinner" class="text-center">
+            <span class="fa fa-spinner fa-spin fa-2x" aria-hidden="true"></span>
+            <span class="sr-only">Loading...</span>
+          </div>
+          <div id="items-modal-content" class="d-none"></div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
**ISSUE**
We are generally only interested in a specific error message, not all of them. And when the error isn't on our own job, we don't care at all. Unfortunately, the UI was giving a lot of screen real estate to error messages if they were even a little bit long.

**RESOLUTION**
Remove the error message from the main index view and only display error text in the Export details pop-up.

<img width="1652" height="689" alt="image" src="https://github.com/user-attachments/assets/0e0fe5d4-e0aa-41af-bf5e-5fe911e2d0da" />

<img width="705" height="830" alt="image" src="https://github.com/user-attachments/assets/bf37a880-9cd3-4586-a77f-d74065666cd0" />
