### PR TITLE
Persist ActiveStorage attachments across deploys

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,6 +27,7 @@ SSHKit.config.command_map[:rake] = 'bundle exec rake'
 set :branch, ENV['REVISION'] || ENV['BRANCH_NAME'] || ENV['BRANCH'] || 'main'
 
 append :linked_dirs, "log"
+append :linked_dirs, "storage"
 append :linked_dirs, "public/assets"
 
 append :linked_files, "config/database.yml"


### PR DESCRIPTION
**ISSUE**
Active storage defaults to "#{Rails.root}/storage" which is recreated from scratch by default on each deploy using Capistrano.

**FIX**
Share the "./storage/" directory across deploys.