### PR TITLE
Add Rake task to normalize date_modified

### DIFF
--- a/lib/tasks/cypripedium.rake
+++ b/lib/tasks/cypripedium.rake
@@ -19,4 +19,33 @@ namespace :cypripedium do
     admin_role.users << u
     admin_role.save!
   end
+
+  desc "Normalize date_modified field"
+  task normalize_date_modified: :environment do
+    current_offset = 0
+    documents = [{ 'id' => 'dummy' }] # dummy value to trigger first loop iteration
+    ids = []
+    puts "===================================================="
+    while documents.present?
+      print "\rFetching documents from Solr (offset: #{current_offset})"
+      $stdout.flush
+      response = Hyrax::SolrService.get('date_modified_ssi:*', rows: 100, start: current_offset)
+      documents = response.dig('response', 'docs') || []
+      ids += documents.map { |doc| doc['id'] }
+      current_offset += 100
+    end
+
+    puts "\n"
+    total = ids.length
+    ids.each.with_index do |id, index|
+      af_object = ActiveFedora::Base.find(id)
+      af_object.date_modified = af_object.date_modified.in_time_zone
+      af_object.save!
+
+      print "\rProcessing #{index} of #{total}"
+      $stdout.flush
+    end
+
+    puts "\n"
+  end
 end


### PR DESCRIPTION
**ISSUE**
Approximately 1700 records have the `date_modified` value stored as a `String` instead of a `DateTime` object. This causes errors when trying to call DateTime methods on the value. It also causes the value to be indexed as `date_modified_ssi` instead of `date_modified_dtsi` which prevents the value from being displayed in certain contexts.

NOTE: It appears this may be a leftover from Hyrax 2.x code.

**RESOLUTION**
Add a rake task that searches for items indexed with `date_modified_ssi` i.e. with `String` values, and updates them to a `DateTime` value. The items are correctly reindexed as part of the save process.