### PR TITLE
Increase text witdth on facet modal boxes

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -282,3 +282,7 @@ when there are more than one values in a field.
 .form-tab-content .multi_value li.field-wrapper:last-of-type .remove {
   display: none;
 }
+
+#blacklight-modal .facet-label {
+  width: 95%;
+}


### PR DESCRIPTION
**ISSUE**
Facet lables were only being dynamically allocated 50% of the available display width, resulting in significant white space between the label and the corresponding count.

**RESOLUTION**
Explicitly set the label witdth to better use available space.

## BEFORE
<img width="652" height="882" alt="image" src="https://github.com/user-attachments/assets/70890f8d-58d3-4301-8d85-d9847a60e7a6" />

## AFTER
<img width="649" height="649" alt="image" src="https://github.com/user-attachments/assets/1e7fb4ee-831c-4a43-ae9c-83ec3b7e4d52" />
